### PR TITLE
PyCon 2013 sprint - buildout changes

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,9 +1,12 @@
 [buildout]
+extensions = mr.developer
 develop = .
 parts =
     test
     scripts
 versions = versions
+always-checkout = true
+auto-checkout = *
 
 [versions]
 zc.recipe.testrunner = 2.0.0
@@ -14,6 +17,9 @@ BTrees = 4.0.5
 persistent = 4.0.6
 transaction = 1.4.1
 zdaemon = 4.0.0a1
+
+[sources]
+zodbpickle = git https://github.com/zopefoundation/zodbpickle.git
 
 [test]
 recipe = zc.recipe.testrunner


### PR DESCRIPTION
Adds a version bump for ZConfig and pulls in the development version of zodbpickle. Doing this allows all the ZODB tests to pass on my machine.
