### PR TITLE
UnicodeDecodeError with bushy blob layout and non-ASCII OID

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
  Change History
 ================
 
+Unreleased
+==========
+
+- Fixed: A ``UnicodeDecodeError`` could happen for non-ASCII OIDs
+  when using bushy blob layout.
+
 4.0.0b2 (2013-05-14)
 ====================
 
@@ -16,7 +22,7 @@
 - Skipped non-unit tests in ``setup.py test``.  Use the buildout to run tests
   requiring "layer" support.
 
-- Included the filename in the exception message to support debugging in case 
+- Included the filename in the exception message to support debugging in case
   ``loadBlob`` does not find the file.
 
 - Added support for Python 3.2 / 3.3.

--- a/src/ZODB/blob.py
+++ b/src/ZODB/blob.py
@@ -35,6 +35,7 @@ from ZODB._compat import BytesIO
 from ZODB._compat import Unpickler
 from ZODB._compat import decodebytes
 from ZODB._compat import ascii_bytes
+from ZODB._compat import INT_TYPES
 
 
 if sys.version_info[0] >= 3:
@@ -552,9 +553,14 @@ class BushyLayout(object):
         directories = []
         # Create the bushy directory structure with the least significant byte
         # first
-        for byte in oid.decode():
-            directories.append(
-                '0x%s' % binascii.hexlify(byte.encode()).decode())
+        for byte in ascii_bytes(oid):
+            if isinstance(byte,INT_TYPES): # Py3k iterates byte strings as ints
+                hex_segment_bytes = b'0x' + binascii.hexlify(bytes([byte]))
+                hex_segment_string = hex_segment_bytes.decode('ascii')
+            else:
+                hex_segment_string = '0x%s' % binascii.hexlify(byte)
+            directories.append(hex_segment_string)
+
         return os.path.sep.join(directories)
 
     def path_to_oid(self, path):


### PR DESCRIPTION
When we updated from ZODB 4.0.0a4 to 4.0.0b2 running under Python 2.7 some of our unit tests started breaking with tracebacks like this:

>  Module ZODB.Connection, line 569, in commit
>    self._commit(transaction)
>  Module ZODB.Connection, line 625, in _commit
>    self._store_objects(ObjectWriter(obj), transaction)
>  Module ZODB.Connection, line 677, in _store_objects
>    '', transaction)
>  Module ZODB.DemoStorage, line 305, in storeBlob
>    oid, oldserial, data, blobfilename, '', transaction)
>  Module ZODB.blob, line 691, in storeBlob
>    self._blob_storeblob(oid, serial, blobfilename)
>  Module ZODB.blob, line 676, in _blob_storeblob
>    self.fshelper.getPathForOID(oid, create=True)
>  Module ZODB.blob, line 391, in getPathForOID
>    path = self.layout.oid_to_path(oid)
>  Module ZODB.blob, line 555, in oid_to_path
>    for byte in oid.decode():
> UnicodeDecodeError: 'ascii' codec can't decode byte 0xcb in position 1: ordinal not in range(128)

The OID in question looked something like  `b'>\xf1<0\xe9Q\x99\xf0'`. This seems to have changed in e7d8ca7229998146f79e1f90302ae6486bc95a60.

The attached pull request adds a test for this case and changes `ZODB.blob:BushyLayout.oid_to_path` to not be dependent on the default character encoding and to produce the correct results in this case under all tox environments (though it's probably not as efficient as it could be?). 
