### PR TITLE
Set the persistent_id attribute of the pickler even under Py2 for PyPy

### DIFF
--- a/src/ZODB/serialize.py
+++ b/src/ZODB/serialize.py
@@ -175,6 +175,11 @@ class ObjectWriter:
         self._p = Pickler(self._file, _protocol)
         if sys.version_info[0] < 3:
             self._p.inst_persistent_id = self.persistent_id
+            # PyPy uses a python implementation of cPickle in both Python 2
+            # and Python 3. We can't really detect inst_persistent_id as its
+            # a magic attribute that's not readable, but it doesn't hurt to
+            # simply always assign to persistent_id also
+            self._p.persistent_id = self.persistent_id
         else:
             self._p.persistent_id = self.persistent_id
         self._stack = []


### PR DESCRIPTION
I've been working on getting `zope.container` usable under with PyPy. The test cases for `zope.container` make heavy use of ZODB and persistent objects. PyPy's implementation of cPickle is actually written in Python, so it doesn't have the `inst_persistent_id` attribute under Python 2. Instead, it always has and uses the `persistent_id` attribute; if only the `inst_persistent_id` value is set, then PyPy's pickler will never write out persistent ids correctly.

This commit causes `ZODB.serialize.ObjectWriter` to also set the `persistent_id` attribute. This lets the `zope.container` tests pass under PyPy, and doesn't break any of the tests for ZODB under cPython 2.6 or 2.7. 
