### PR TITLE
Cleaned up exception logging and changed pins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
     - 3.3
     - 3.4
 install:
-    - travis_retry pip install BTrees ZConfig manuel persistent six transaction zc.lockfile zdaemon zope.interface zope.testing zope.testrunner
+    - travis_retry pip install BTrees ZConfig manuel persistent six transaction zc.lockfile zdaemon zope.interface zope.testing zope.testrunner=4.4.4
     - travis_retry pip install -e .
 script:
     - zope-testrunner -u --test-path=src --auto-color --auto-progress

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
     - 3.3
     - 3.4
 install:
-    - travis_retry pip install BTrees ZConfig manuel persistent six transaction zc.lockfile zdaemon zope.interface zope.testing zope.testrunner=4.4.4
+    - travis_retry pip install BTrees ZConfig manuel persistent six transaction zc.lockfile zdaemon zope.interface zope.testing zope.testrunner==4.4.4
     - travis_retry pip install -e .
 script:
     - zope-testrunner -u --test-path=src --auto-color --auto-progress

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -3,17 +3,18 @@ develop = .
 parts =
     test
     scripts
-versions = versions
 
 [versions]
-zc.recipe.testrunner = 2.0.0
-zc.lockfile = 1.1.0
-zope.interface = 4.0.3
-ZConfig = 3.0.3
-BTrees = 4.0.5
-persistent = 4.0.6
-transaction = 1.4.1
-zdaemon = 4.0.0a1
+# Avoid breakage in 4.4.5:
+zope.testrunner = 4.4.4
+# zc.recipe.testrunner = 2.0.0
+# zc.lockfile = 1.1.0
+# zope.interface = 4.0.3
+# ZConfig = 3.0.3
+# BTrees = 4.0.5
+# persistent = 4.0.6
+# transaction = 1.4.1
+# zdaemon = 4.0.0a1
 
 [test]
 recipe = zc.recipe.testrunner

--- a/src/ZODB/ConflictResolution.py
+++ b/src/ZODB/ConflictResolution.py
@@ -302,7 +302,7 @@ def tryToResolveConflict(self, oid, committedSerial, oldSerial, newpickle,
         # the original ConflictError.  A client can recover from a
         # ConflictError, but not necessarily from other errors.  But log
         # the error so that any problems can be fixed.
-        logger.error("Unexpected error", exc_info=True)
+        logger.exception("Unexpected error")
 
     raise ConflictError(oid=oid, serials=(committedSerial, oldSerial),
                         data=newpickle)

--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -302,8 +302,7 @@ class Connection(ExportImport, object):
                     f()
                 except: # except what?
                     f = getattr(f, 'im_self', f)
-                    self._log.error("Close callback failed for %s", f,
-                                    exc_info=sys.exc_info())
+                    self._log.exception("Close callback failed for %s", f)
             self.__onCloseCallbacks = None
 
         self._debug_info = ()
@@ -874,8 +873,7 @@ class Connection(ExportImport, object):
             raise
         except:
             self._log.exception("Couldn't load state for %s %s",
-                                className(obj), oid_repr(oid),
-                                exc_info=sys.exc_info())
+                                className(obj), oid_repr(oid))
             raise
 
     def _setstate(self, obj):

--- a/src/ZODB/DB.py
+++ b/src/ZODB/DB.py
@@ -809,7 +809,7 @@ class DB(object):
         try:
             self.storage.pack(t, self.references)
         except:
-            logger.error("packing", exc_info=True)
+            logger.exception("packing")
             raise
 
     def setActivityMonitor(self, am):

--- a/src/ZODB/FileStorage/FileStorage.py
+++ b/src/ZODB/FileStorage/FileStorage.py
@@ -429,7 +429,7 @@ class FileStorage(
             self._save_index()
         except:
             # Log the error and continue
-            logger.error("Error saving index on close()", exc_info=True)
+            logger.exception("Error saving index on close()")
 
     def getSize(self):
         return self._pos
@@ -1665,8 +1665,7 @@ def _truncate(file, name, pos):
                 o.close()
                 break
     except:
-        logger.error("couldn\'t write truncated data for %s", name,
-              exc_info=True)
+        logger.exception("couldn\'t write truncated data for %s", name)
         raise StorageSystemError("Couldn't save truncated data")
 
     file.seek(pos)


### PR DESCRIPTION
- Always use logger.exception rather than logging.error when logging
  exceptions ar the error level.

- Fixed an incorrect call to logging.exceotion (like PR #26, but better :).

- Removed dependency pins and added one to overcome some breakage in
  zope.testrunner.

None of this seems to be CHANGES worthy.