### PR TITLE
For discussion: Add scripts to create/modify dbs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,6 +162,8 @@ setup(name="ZODB",
       zip_safe = False,
       entry_points = """
       [console_scripts]
+      fsanalyze = ZODB.scripts.analyze:main
+      fscreate = ZODB.scripts.create:main
       fsdump = ZODB.FileStorage.fsdump:main
       fsoids = ZODB.scripts.fsoids:main
       fsrefs = ZODB.scripts.fsrefs:main

--- a/src/ZODB/scripts/analyze.py
+++ b/src/ZODB/scripts/analyze.py
@@ -144,6 +144,9 @@ def analyze_rec(report, record):
     except Exception as err:
         print(err)
 
-if __name__ == "__main__":
+def main():
     path = sys.argv[1]
     report(analyze(path))
+
+if __name__ == "__main__":
+    main()

--- a/src/ZODB/scripts/create.py
+++ b/src/ZODB/scripts/create.py
@@ -1,0 +1,23 @@
+import ZODB
+import ZODB.FileStorage
+
+
+def main():
+    """
+    Console script to create db
+    """
+    storage = ZODB.FileStorage.FileStorage('Data.fs')
+    db = ZODB.DB(storage)
+    connection = db.open()
+    root = connection.root
+    # XXX Consider allowing end user to create a db w/values
+    # e.g. createdb 'foo=bar'
+    print('Created database with contents %s.' % root._root)
+
+
+if __name__ == '__main__':
+
+    """
+    Execute console script to create db
+    """
+    main()


### PR DESCRIPTION
- Add fscreate to create db
- Add analyze.py to console scripts as fsanalyze

I'd like to make ZODB to "more approachable to end users" by allowing them to "interact without writing code" e.g.:

```
$ bin/fscreate                                         
Created database with contents {}.
$ bin/fsanalyze Data.fs                                
Processed 1 records in 1 transactions
Average record size is   60.00 bytes
Average transaction size is   60.00 bytes
Types used:
Class Name                                       Count    TBytes    Pct AvgSize
---------------------------------------------- ------- ---------  ----- -------
persistent.mapping.PersistentMapping                 1        60 100.0%   60.00
============================================== ======= =========  ===== =======
                            Total Transactions       1                    0.06k
                                 Total Records       1        0k 100.0%   60.00
                               Current Objects       1        0k 100.0%   60.00
```

Starting with the code in this PR, what additional code/features/etc would be required to get this merged into ZODB? I'm picturing being able to:

```
fscreate 'foo=bar' 
fsadd 'morekeys=morevalues'
```

And so on.
