### PR TITLE
Support PyPy. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ coverage.xml
 dist
 testing.log
 .eggs/
+.dir-locals.el

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 sudo: false
 python:
     - pypy
+    - pypy3
     - 2.6
     - 2.7
     - 3.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 sudo: false
 python:
+    - pypy
     - 2.6
     - 2.7
     - 3.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
     - 3.3
     - 3.4
 install:
-    - travis_retry pip install BTrees ZConfig manuel persistent six transaction zc.lockfile zdaemon zope.interface zope.testing zope.testrunner==4.4.4
+    - travis_retry pip install BTrees ZConfig manuel persistent six transaction zc.lockfile zdaemon zope.interface zope.testing zope.testrunner
     - travis_retry pip install -e .
 script:
     - zope-testrunner -u --test-path=src --auto-color --auto-progress

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,9 +8,10 @@
 - Fix command-line parsing of --verbose and --verify arguments.
   (The short versions -v and -V were parsed correctly.)
 
-- Add support for PyPy, and fix the methods in `ZODB.serialize` that
-  find object references under Python 2.7. This requires the addition
-  of the `zodbpickle` dependency.
+- Add support for PyPy, and fix the methods in ``ZODB.serialize`` that
+  find object references under Python 2.7 (used in scripts like
+  ``referrers``, ``netspace``, and ``fsrecover`` among others). This
+  requires the addition of the ``zodbpickle`` dependency.
 
 4.1.0 (2015-01-11)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,11 +2,15 @@
  Change History
 ================
 
-4.1.1 (unreleased)
+4.2.0 (unreleased)
 ==================
 
 - Fix command-line parsing of --verbose and --verify arguments.
   (The short versions -v and -V were parsed correctly.)
+
+- Add support for PyPy, and fix the methods in `ZODB.serialize` that
+  find object references under Python 2.7. This requires the addition
+  of the `zodbpickle` dependency.
 
 4.1.0 (2015-01-11)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@
 - Fix command-line parsing of --verbose and --verify arguments.
   (The short versions -v and -V were parsed correctly.)
 
-- Add support for PyPy and Jython 2.7.
+- Add support for PyPy.
 
 - Fix the methods in ``ZODB.serialize`` that find object references
   under Python 2.7 (used in scripts like ``referrers``, ``netspace``,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,10 +8,12 @@
 - Fix command-line parsing of --verbose and --verify arguments.
   (The short versions -v and -V were parsed correctly.)
 
-- Add support for PyPy, and fix the methods in ``ZODB.serialize`` that
-  find object references under Python 2.7 (used in scripts like
-  ``referrers``, ``netspace``, and ``fsrecover`` among others). This
-  requires the addition of the ``zodbpickle`` dependency.
+- Add support for PyPy and Jython 2.7.
+
+- Fix the methods in ``ZODB.serialize`` that find object references
+  under Python 2.7 (used in scripts like ``referrers``, ``netspace``,
+  and ``fsrecover`` among others). This requires the addition of the
+  ``zodbpickle`` dependency.
 
 4.1.0 (2015-01-11)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: Implementation :: CPython
 Programming Language :: Python :: Implementation :: PyPy
-Programming Language :: Python :: Implementation :: Jython
 Topic :: Database
 Topic :: Software Development :: Libraries :: Python Modules
 Operating System :: Microsoft :: Windows

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: Implementation :: CPython
 Programming Language :: Python :: Implementation :: PyPy
+Programming Language :: Python :: Implementation :: Jython
 Topic :: Database
 Topic :: Software Development :: Libraries :: Python Modules
 Operating System :: Microsoft :: Windows

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ to application logic.  ZODB includes features such as a plugable storage
 interface, rich transaction support, and undo.
 """
 
-VERSION = "4.1.0"
+VERSION = "4.2.0.dev0"
 
 import os
 import platform
@@ -59,6 +59,7 @@ Programming Language :: Python :: 3.2
 Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: Implementation :: CPython
+Programming Language :: Python :: Implementation :: PyPy
 Topic :: Database
 Topic :: Software Development :: Libraries :: Python Modules
 Operating System :: Microsoft :: Windows
@@ -158,7 +159,7 @@ setup(name="ZODB",
       tests_require = tests_require,
       extras_require = dict(test=tests_require),
       install_requires = [
-        'persistent',
+        'persistent', # XXX: When new persistent release is out need to add version number for PyPy
         'BTrees >= 4.1.2',
         'ZConfig',
         'transaction >= 1.4.1' if PY3 else 'transaction',

--- a/setup.py
+++ b/setup.py
@@ -160,10 +160,10 @@ setup(name="ZODB",
       tests_require = tests_require,
       extras_require = dict(test=tests_require),
       install_requires = [
-        'persistent', # XXX: When new persistent release is out need to add version number for PyPy
-        'BTrees >= 4.1.2',
+        'persistent >= 4.1.0',
+        'BTrees >= 4.1.3',
         'ZConfig',
-        'transaction >= 1.4.1' if PY3 else 'transaction',
+        'transaction >= 1.4.4',
         'six',
         'zc.lockfile',
         'zdaemon >= 4.0.0a1',

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ interface, rich transaction support, and undo.
 VERSION = "4.1.0"
 
 import os
+import platform
 import sys
 from setuptools import setup, find_packages
 
@@ -35,6 +36,10 @@ if (3,) < sys.version_info < (3, 2):
     sys.exit(0)
 
 PY3 = sys.version_info >= (3,)
+PY27 = sys.version_info >= (2,7)
+py_impl = getattr(platform, 'python_implementation', lambda: None)
+PYPY = py_impl() == 'PyPy'
+
 
 # The (non-obvious!) choices for the Trove Development Status line:
 # Development Status :: 5 - Production/Stable
@@ -154,14 +159,14 @@ setup(name="ZODB",
       extras_require = dict(test=tests_require),
       install_requires = [
         'persistent',
-        'BTrees',
+        'BTrees >= 4.1.2',
         'ZConfig',
         'transaction >= 1.4.1' if PY3 else 'transaction',
         'six',
         'zc.lockfile',
         'zdaemon >= 4.0.0a1',
         'zope.interface',
-        ] + (['zodbpickle >= 0.2'] if PY3 else []),
+        ] + (['zodbpickle >= 0.6.0'] if (PY3 or PY27 or PYPY) else []),
       zip_safe = False,
       entry_points = """
       [console_scripts]

--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -439,7 +439,6 @@ class Connection(ExportImport, object):
         # the savepoint, then they won't have _p_oid or _p_jar after
         # they've been unadded. This will make the code in _abort
         # confused.
-
         self._abort()
 
         if self._savepoint_storage is not None:
@@ -463,7 +462,6 @@ class Connection(ExportImport, object):
                 if obj._p_changed:
                     obj._p_changed = False
             else:
-
                 # Note: If we invalidate a non-ghostifiable object
                 # (i.e. a persistent class), the object will
                 # immediately reread its state.  That means that the

--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -1018,10 +1018,9 @@ class Connection(ExportImport, object):
         items = self._cache.lru_items()
         # fine everything. some on the lru list, some not
         everything = self._cache.cache_data
-        # remove those items that are on the lru list (which may not actually
-        # be in the full cache, under the Python implementation)
+        # remove those items that are on the lru list
         for k,v in items:
-            everything.pop(k, None)
+            del everything[k]
         # return a list of [ghosts....not recently used.....recently used]
         return list(everything.items()) + items
 

--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -328,10 +328,10 @@ class Connection(ExportImport, object):
                 # get back here.
         else:
             self.opened = None
-            
+
         am = self._db._activity_monitor
         if am is not None:
-            am.closedConnection(self)        
+            am.closedConnection(self)
 
     def db(self):
         """Returns a handle to the database this connection belongs to."""
@@ -1020,9 +1020,10 @@ class Connection(ExportImport, object):
         items = self._cache.lru_items()
         # fine everything. some on the lru list, some not
         everything = self._cache.cache_data
-        # remove those items that are on the lru list
+        # remove those items that are on the lru list (which may not actually
+        # be in the full cache, under the Python implementation)
         for k,v in items:
-            del everything[k]
+            everything.pop(k, None)
         # return a list of [ghosts....not recently used.....recently used]
         return list(everything.items()) + items
 

--- a/src/ZODB/DB.py
+++ b/src/ZODB/DB.py
@@ -530,7 +530,13 @@ class DB(object):
     def cacheExtremeDetail(self):
         detail = []
         conn_no = [0]  # A mutable reference to a counter
-        def f(con, detail=detail, rc=sys.getrefcount, conn_no=conn_no):
+        try:
+            rc = sys.getrefcount
+        except AttributeError:
+            # sys.getrefcount is a CPython implementation detail
+            # not required to exist on, e.g., PyPy. Here we fake it.
+            rc = lambda o: 4
+        def f(con, detail=detail, rc=rc, conn_no=conn_no):
             conn_no[0] += 1
             cn = conn_no[0]
             for oid, ob in con._cache_items():

--- a/src/ZODB/DB.py
+++ b/src/ZODB/DB.py
@@ -530,12 +530,10 @@ class DB(object):
     def cacheExtremeDetail(self):
         detail = []
         conn_no = [0]  # A mutable reference to a counter
-        try:
-            rc = sys.getrefcount
-        except AttributeError:
-            # sys.getrefcount is a CPython implementation detail
-            # not required to exist on, e.g., PyPy. Here we fake it.
-            rc = lambda o: 4
+        # sys.getrefcount is a CPython implementation detail
+        # not required to exist on, e.g., PyPy.
+        rc = getattr(sys, 'getrefcount', None)
+
         def f(con, detail=detail, rc=rc, conn_no=conn_no):
             conn_no[0] += 1
             cn = conn_no[0]
@@ -561,12 +559,15 @@ class DB(object):
                 # sys.getrefcount(ob) returns.  But, in addition to that,
                 # the cache holds an extra reference on non-ghost objects,
                 # and we also want to pretend that doesn't exist.
+                # If we have no way to get a refcount, we return False to symbolize
+                # that. As opposed to None, this has the advantage of being usable
+                # as a number (0) in case clients depended on that
                 detail.append({
                     'conn_no': cn,
                     'oid': oid,
                     'id': id,
                     'klass': "%s%s" % (module, ob.__class__.__name__),
-                    'rc': rc(ob) - 3 - (ob._p_changed is not None),
+                    'rc': rc(ob) - 3 - (ob._p_changed is not None) if rc else False,
                     'state': ob._p_changed,
                     #'references': con.references(oid),
                     })

--- a/src/ZODB/DB.py
+++ b/src/ZODB/DB.py
@@ -561,7 +561,7 @@ class DB(object):
                 # and we also want to pretend that doesn't exist.
                 # If we have no way to get a refcount, we return False to symbolize
                 # that. As opposed to None, this has the advantage of being usable
-                # as a number (0) in case clients depended on that
+                # as a number (0) in case clients depended on that.
                 detail.append({
                     'conn_no': cn,
                     'oid': oid,

--- a/src/ZODB/DemoStorage.test
+++ b/src/ZODB/DemoStorage.test
@@ -14,7 +14,10 @@ existing, base, storage without updating the storage.
     ...     return now
     >>> import time
     >>> real_time_time = time.time
-    >>> time.time = faux_time_time
+    >>> if isinstance(time,type):
+    ...    time.time = staticmethod(faux_time_time) # Jython
+    ... else:
+    ...     time.time = faux_time_time
 
 To see how this works, we'll start by creating a base storage and
 puting an object (in addition to the root object) in it:
@@ -44,6 +47,13 @@ and combine the 2 in a demofilestorage:
 
     >>> from ZODB.DemoStorage import DemoStorage
     >>> storage = DemoStorage(base=base, changes=changes)
+
+The storage will assign OIDs in a pseudo-random fashion, but for test
+purposes we need to control where they start (since the random seeds
+can be different on different platforms):
+
+    >>> storage._next_oid = 3553260803050964942
+
 
 If there are no transactions, the storage reports the lastTransaction
 of the base database:

--- a/src/ZODB/DemoStorage.test
+++ b/src/ZODB/DemoStorage.test
@@ -375,12 +375,12 @@ Now, we create a demostorage.
 
 If we ask for an oid, we'll get 1042.
 
-    >>> u64(storage.new_oid())
+    >>> print(u64(storage.new_oid()))
     1042
 
 oids are allocated seuentially:
 
-    >>> u64(storage.new_oid())
+    >>> print(u64(storage.new_oid()))
     1043
 
 Now, we'll save 1044 in changes so that it has to pick a new one randomly.
@@ -388,7 +388,7 @@ Now, we'll save 1044 in changes so that it has to pick a new one randomly.
     >>> t = transaction.get()
     >>> ZODB.tests.util.store(storage.changes, 1044)
 
-    >>> u64(storage.new_oid())
+    >>> print(u64(storage.new_oid()))
     called randint
     2042
 
@@ -400,7 +400,7 @@ to force another attempt:
     >>> oid = storage.new_oid()
     called randint
     called randint
-    >>> u64(oid)
+    >>> print(u64(oid))
     3042
 
 DemoStorage keeps up with the issued OIDs to know when not to reissue them...
@@ -426,4 +426,3 @@ DemoStorage keeps up with the issued OIDs to know when not to reissue them...
 .. restore time
 
     >>> time.time = real_time_time
-

--- a/src/ZODB/ExportImport.py
+++ b/src/ZODB/ExportImport.py
@@ -15,7 +15,6 @@
 
 import logging
 import os
-import sys
 from tempfile import TemporaryFile
 
 import six
@@ -25,7 +24,7 @@ from ZODB.interfaces import IBlobStorage
 from ZODB.POSException import ExportError
 from ZODB.serialize import referencesf
 from ZODB.utils import p64, u64, cp, mktemp
-from ZODB._compat import Pickler, Unpickler, BytesIO, _protocol
+from ZODB._compat import PersistentPickler, Unpickler, BytesIO, _protocol
 
 
 logger = logging.getLogger('ZODB.ExportImport')
@@ -178,11 +177,7 @@ class ExportImport:
             unpickler.persistent_load = persistent_load
 
             newp = BytesIO()
-            pickler = Pickler(newp, _protocol)
-            if sys.version_info[0] < 3:
-                pickler.inst_persistent_id = persistent_id
-            else:
-                pickler.persistent_id = persistent_id
+            pickler = PersistentPickler(persistent_id, newp, _protocol)
 
             pickler.dump(unpickler.load())
             pickler.dump(unpickler.load())

--- a/src/ZODB/FileStorage/iterator.test
+++ b/src/ZODB/FileStorage/iterator.test
@@ -13,7 +13,10 @@ We'll make some assertions about time, so we'll take it over:
     ...     return now
     >>> import time
     >>> time_time = time.time
-    >>> time.time = faux_time
+    >>> if isinstance(time,type):
+    ...    time.time = staticmethod(faux_time) # Jython
+    ... else:
+    ...     time.time = faux_time
 
 Commit a bunch of transactions:
 

--- a/src/ZODB/POSException.py
+++ b/src/ZODB/POSException.py
@@ -61,6 +61,16 @@ class POSError(Exception):
 
             return (_recon, (self.__class__, state))
 
+        def __setstate__(self, state):
+            # PyPy doesn't store the 'args' attribute in an instance's
+            # __dict__; instead, it uses what amounts to a slot. Because
+            # we customize the pickled representation to just be a dictionary,
+            # the args would then get lost, leading to unprintable exceptions
+            # and worse. Manually assign to args from the state to be sure
+            # this doesn't happen.
+            super(POSError,self).__setstate__(state)
+            self.args = state['args']
+
 class POSKeyError(POSError, KeyError):
     """Key not found in database."""
 

--- a/src/ZODB/_compat.py
+++ b/src/ZODB/_compat.py
@@ -11,15 +11,24 @@
 # FOR A PARTICULAR PURPOSE
 #
 ##############################################################################
+import sys
 
 try:
     # Python 2.x
-    from cPickle import Pickler
-    from cPickle import Unpickler
-    from cPickle import dump
-    from cPickle import dumps
-    from cPickle import loads
-    from cPickle import HIGHEST_PROTOCOL
+    import cPickle
+    if not hasattr(cPickle.Unpickler, 'noload') or sys.version_info >= (2,7):
+        # PyPy doesn't have noload, and noload is broken in Python 2.7.
+        # Get the fastest version we can (PyPy has no fastpickle)
+        try:
+            import zodbpickle.fastpickle as cPickle
+        except ImportError:
+            import zodbpickle.pickle as cPickle
+    Pickler = cPickle.Pickler
+    Unpickler = cPickle.Unpickler
+    dump = cPickle.dump
+    dumps = cPickle.dumps
+    loads = cPickle.loads
+    HIGHEST_PROTOCOL = cPickle.HIGHEST_PROTOCOL
     IMPORT_MAPPING = {}
     NAME_MAPPING = {}
     _protocol = 1

--- a/src/ZODB/_compat.py
+++ b/src/ZODB/_compat.py
@@ -18,7 +18,8 @@ IS_JYTHON = sys.platform.startswith('java')
 try:
     # Python 2.x
     import cPickle
-    if (hasattr(cPickle.Unpickler, 'load') and not hasattr(cPickle.Unpickler, 'noload')) or sys.version_info >= (2,7):
+    if ((hasattr(cPickle.Unpickler, 'load') and not hasattr(cPickle.Unpickler, 'noload')) or
+		sys.version_info >= (2,7)):
         # PyPy doesn't have noload, and noload is broken in Python 2.7.
         # Get the fastest version we can (PyPy has no fastpickle)
         try:
@@ -83,13 +84,12 @@ def PersistentPickler(persistent_id, *args, **kwargs):
     p = Pickler(*args, **kwargs)
     if sys.version_info[0] < 3:
         p.inst_persistent_id = persistent_id
-        # PyPy uses a python implementation of cPickle in both Python 2
-        # and Python 3. We can't really detect inst_persistent_id as its
-        # a magic attribute that's not readable, but it doesn't hurt to
-        # simply always assign to persistent_id also
-        p.persistent_id = persistent_id
-    else:
-        p.persistent_id = persistent_id
+
+    # PyPy uses a python implementation of cPickle/zodbpickle in both Python 2
+    # and Python 3. We can't really detect inst_persistent_id as its
+    # a magic attribute that's not readable, but it doesn't hurt to
+    # simply always assign to persistent_id also
+    p.persistent_id = persistent_id
     return p
 
 def PersistentUnpickler(find_global, load_persistent, *args, **kwargs):
@@ -114,16 +114,8 @@ def PersistentUnpickler(find_global, load_persistent, *args, **kwargs):
 
 
 try:
-    # Python 2.x
-    if IS_JYTHON:
-        # Jython 2.7rc2 cStringIO.StringIO class has a bug
-        # resulting in StringIndexOutOfBoundExceptions
-        # when repeatedly writing and then seeking back to 0
-        # http://bugs.jython.org/issue2324
-        from io import BytesIO
-    else:
-        # XXX: why not just import BytesIO from io?
-        from cStringIO import StringIO as BytesIO
+    # XXX: why not just import BytesIO from io?
+    from cStringIO import StringIO as BytesIO
 except ImportError:
     # Python 3.x
     from io import BytesIO

--- a/src/ZODB/_compat.py
+++ b/src/ZODB/_compat.py
@@ -13,6 +13,8 @@
 ##############################################################################
 import sys
 
+IS_JYTHON = sys.platform.startswith('java')
+
 try:
     # Python 2.x
     import cPickle
@@ -113,8 +115,15 @@ def PersistentUnpickler(find_global, load_persistent, *args, **kwargs):
 
 try:
     # Python 2.x
-    # XXX: why not just import BytesIO from io?
-    from cStringIO import StringIO as BytesIO
+    if IS_JYTHON:
+        # Jython 2.7rc2 cStringIO.StringIO class has a bug
+        # resulting in StringIndexOutOfBoundExceptions
+        # when repeatedly writing and then seeking back to 0
+        # http://bugs.jython.org/issue2324
+        from io import BytesIO
+    else:
+        # XXX: why not just import BytesIO from io?
+        from cStringIO import StringIO as BytesIO
 except ImportError:
     # Python 3.x
     from io import BytesIO

--- a/src/ZODB/blob.py
+++ b/src/ZODB/blob.py
@@ -61,10 +61,10 @@ valid_modes = 'r', 'w', 'r+', 'a', 'c'
 # of a weakref when the weakref object dies at the same time
 # as the object it refers to. In other words, this doesn't work:
 #    self._ref = weakref.ref(self, lambda ref: ...)
-# because the function never gets called. The Blob class used
-# to use that pattern to clean up uncommitted files; now we use this
-# module-level global (but still keep a reference in the Blob in case
-# we need premature cleanup)
+# because the function never gets called (https://bitbucket.org/pypy/pypy/issue/2030).
+# The Blob class used to use that pattern to clean up uncommitted
+# files; now we use this module-level global (but still keep a
+# reference in the Blob in case we need premature cleanup).
 _blob_close_refs = []
 
 @zope.interface.implementer(ZODB.interfaces.IBlob)

--- a/src/ZODB/blob.py
+++ b/src/ZODB/blob.py
@@ -76,14 +76,7 @@ class Blob(persistent.Persistent):
     _p_blob_committed = None    # Filename of the committed data
     _p_blob_ref = None          # weakreference to self; also in _blob_close_refs
 
-    # Use volatile attributes so as not to spuriously mark as changed.
-    # The properties are aliases for BWC
-    readers = property(lambda self: getattr(self, '_v_readers', None),
-                       lambda self, nv: setattr(self, '_v_readers', nv))
-    writers = property(lambda self: getattr(self, '_v_writers', None),
-                       lambda self, nv: setattr(self, '_v_writers', nv))
-    _v_readers = None
-    _v_writers = None
+    readers = writers = None
 
     def __init__(self, data=None):
         # Raise exception if Blobs are getting subclassed
@@ -98,14 +91,8 @@ class Blob(persistent.Persistent):
     def __setstate__(self, state=None):
         # we use lists here because it will allow us to add and remove
         # atomically
-        # Directly use the volatile attributes here, not the property,
-        # because setting the property causes us to get marked as changed,
-        # which registers us with the Connection and hence the transaction;
-        # at least under the Python implementation of persistent this causes
-        # duplicate transaction errors from the storage in testblob.
-        # Plus this way is more efficient anyway :)
-        self._v_readers = []
-        self._v_writers = []
+        self.readers = []
+        self.writers = []
 
     def __getstate__(self):
         return None
@@ -164,8 +151,8 @@ class Blob(persistent.Persistent):
         if self.writers:
             raise BlobError("Already opened for writing.")
 
-        if self._v_readers is None:
-            self._v_readers = []
+        if self.readers is None:
+            self.readers = []
 
         if mode == 'r':
             result = None

--- a/src/ZODB/blob.py
+++ b/src/ZODB/blob.py
@@ -32,7 +32,7 @@ from ZODB.interfaces import BlobError
 from ZODB import utils
 from ZODB.POSException import POSKeyError
 from ZODB._compat import BytesIO
-from ZODB._compat import Unpickler
+from ZODB._compat import PersistentUnpickler
 from ZODB._compat import decodebytes
 from ZODB._compat import ascii_bytes
 from ZODB._compat import INT_TYPES
@@ -937,8 +937,7 @@ def is_blob_record(record):
 
     """
     if record and (b'ZODB.blob' in record):
-        unpickler = Unpickler(BytesIO(record))
-        unpickler.find_global = find_global_Blob
+        unpickler = PersistentUnpickler(find_global_Blob, None, BytesIO(record))
 
         try:
             return unpickler.load() is Blob

--- a/src/ZODB/blob.py
+++ b/src/ZODB/blob.py
@@ -57,6 +57,15 @@ valid_modes = 'r', 'w', 'r+', 'a', 'c'
 # This introduces a threading issue, since a blob file may be destroyed
 # via GC in any thread.
 
+# PyPy 2.5 doesn't properly call the cleanup function
+# of a weakref when the weakref object dies at the same time
+# as the object it refers to. In other words, this doesn't work:
+#    self._ref = weakref.ref(self, lambda ref: ...)
+# because the function never gets called. The Blob class used
+# to use that pattern to clean up uncommitted files; now we use this
+# module-level global (but still keep a reference in the Blob in case
+# we need premature cleanup)
+_blob_close_refs = []
 
 @zope.interface.implementer(ZODB.interfaces.IBlob)
 class Blob(persistent.Persistent):
@@ -65,6 +74,7 @@ class Blob(persistent.Persistent):
 
     _p_blob_uncommitted = None  # Filename of the uncommitted (dirty) data
     _p_blob_committed = None    # Filename of the committed data
+    _p_blob_ref = None          # weakreference to self; also in _blob_close_refs
 
     readers = writers = None
 
@@ -283,8 +293,13 @@ class Blob(persistent.Persistent):
         def cleanup(ref):
             if os.path.exists(filename):
                 os.remove(filename)
-
+            try:
+                _blob_close_refs.remove(ref)
+            except ValueError:
+                pass
         self._p_blob_ref = weakref.ref(self, cleanup)
+        _blob_close_refs.append(self._p_blob_ref)
+
         return filename
 
     def _uncommitted(self):
@@ -293,6 +308,10 @@ class Blob(persistent.Persistent):
         filename = self._p_blob_uncommitted
         if filename is None and self._p_blob_committed is None:
             filename = self._create_uncommitted_file()
+        try:
+            _blob_close_refs.remove(self._p_blob_ref)
+        except ValueError:
+            pass
         self._p_blob_uncommitted = self._p_blob_ref = None
         return filename
 

--- a/src/ZODB/broken.py
+++ b/src/ZODB/broken.py
@@ -23,15 +23,6 @@ import ZODB.interfaces
 from ZODB._compat import IMPORT_MAPPING
 from ZODB._compat import NAME_MAPPING
 
-# Add our magic names to the Python implementation of persistence
-# so that it won't try to re-activate the broken object.
-import persistent.persistence
-persistent.persistence.SPECIAL_NAMES += ('__Broken_newargs__',
-                                         '__Broken_initargs__',
-                                         #'__Broken_state__',
-                                         '__reduce__',
-                                         '__getstate__')
-
 broken_cache = {}
 
 @zope.interface.implementer(ZODB.interfaces.IBroken)

--- a/src/ZODB/broken.py
+++ b/src/ZODB/broken.py
@@ -23,6 +23,14 @@ import ZODB.interfaces
 from ZODB._compat import IMPORT_MAPPING
 from ZODB._compat import NAME_MAPPING
 
+# Add our magic names to the Python implementation of persistence
+# so that it won't try to re-activate the broken object.
+import persistent.persistence
+persistent.persistence.SPECIAL_NAMES += ('__Broken_newargs__',
+                                         '__Broken_initargs__',
+                                         #'__Broken_state__',
+                                         '__reduce__',
+                                         '__getstate__')
 
 broken_cache = {}
 
@@ -308,7 +316,7 @@ class PersistentBroken(Broken, persistent.Persistent):
           >>> a.__reduce__()    # doctest: +NORMALIZE_WHITESPACE
           Traceback (most recent call last):
           ...
-          BrokenModified: 
+          BrokenModified:
           <persistent broken not.there.Atall instance '\x00\x00\x00\x00****'>
 
         but you can get their state:

--- a/src/ZODB/scripts/analyze.py
+++ b/src/ZODB/scripts/analyze.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 import sys
 
 from ZODB.FileStorage import FileStorage
-from ZODB._compat import Unpickler, BytesIO
+from ZODB._compat import PersistentUnpickler, BytesIO
 
 
 
@@ -22,8 +22,7 @@ def fake_find_class(module, name):
 
 
 def FakeUnpickler(f):
-    unpickler = Unpickler(f)
-    unpickler.find_global = fake_find_class
+    unpickler = PersistentUnpickler(fake_find_class, None, f)
     return unpickler
 
 

--- a/src/ZODB/serialize.py
+++ b/src/ZODB/serialize.py
@@ -483,6 +483,10 @@ class ObjectReader:
             return factory(conn, modulename, name)
 
         unpickler.find_global = find_global
+        try:
+            unpickler.find_class = find_global # PyPy, zodbpickle, the non-c-accelerated version
+        except AttributeError:
+            pass
 
         return unpickler
 

--- a/src/ZODB/tests/PackableStorage.py
+++ b/src/ZODB/tests/PackableStorage.py
@@ -15,7 +15,6 @@
 from __future__ import print_function
 
 import doctest
-import sys
 import time
 
 from persistent import Persistent
@@ -26,7 +25,7 @@ from ZODB.serialize import referencesf
 from ZODB.tests.MinPO import MinPO
 from ZODB.tests.MTStorage import TestThread
 from ZODB.tests.StorageTestBase import snooze
-from ZODB._compat import loads, Pickler, Unpickler, BytesIO, _protocol
+from ZODB._compat import loads, PersistentPickler, Pickler, Unpickler, BytesIO, _protocol
 import transaction
 import ZODB.interfaces
 import ZODB.tests.util
@@ -85,11 +84,7 @@ def dumps(obj):
             return obj.getoid()
         return None
     s = BytesIO()
-    p = Pickler(s, _protocol)
-    if sys.version_info[0] < 3:
-        p.inst_persistent_id = getpersid
-    else:
-        p.persistent_id = getpersid
+    p = PersistentPickler(getpersid, s, _protocol)
     p.dump(obj)
     p.dump(None)
     return s.getvalue()

--- a/src/ZODB/tests/StorageTestBase.py
+++ b/src/ZODB/tests/StorageTestBase.py
@@ -25,7 +25,7 @@ import transaction
 
 from ZODB.utils import u64
 from ZODB.tests.MinPO import MinPO
-from ZODB._compat import Pickler, Unpickler, BytesIO, _protocol
+from ZODB._compat import PersistentPickler, Unpickler, BytesIO, _protocol
 import ZODB.tests.util
 
 
@@ -50,11 +50,7 @@ def _persistent_id(obj):
 def zodb_pickle(obj):
     """Create a pickle in the format expected by ZODB."""
     f = BytesIO()
-    p = Pickler(f, _protocol)
-    if sys.version_info[0] < 3:
-        p.inst_persistent_id = _persistent_id
-    else:
-        p.persistent_id = _persistent_id
+    p = PersistentPickler(_persistent_id, f, _protocol)
     klass = obj.__class__
     assert not hasattr(obj, '__getinitargs__'), "not ready for constructors"
     args = None

--- a/src/ZODB/tests/blob_transaction.txt
+++ b/src/ZODB/tests/blob_transaction.txt
@@ -31,7 +31,7 @@ Aborting a blob add leaves the blob unchanged:
     ...     fp.read()
     'this is blob 1'
 
-It doesn't clear the file because there is no previously committed version: 
+It doesn't clear the file because there is no previously committed version:
 
     >>> fname = blob1._p_blob_uncommitted
     >>> import os
@@ -79,7 +79,7 @@ resulting filehandle is accomplished via the filehandle's read method::
     >>> blob1afh1.read()
     'this is blob 1'
 
-Let's make another filehandle for read only to blob1a. Aach file
+Let's make another filehandle for read only to blob1a. Each file
 handle has a reference to the (same) underlying blob::
 
     >>> blob1afh2 = blob1a.open("r")

--- a/src/ZODB/tests/dbopen.txt
+++ b/src/ZODB/tests/dbopen.txt
@@ -228,17 +228,18 @@ that are still alive.
     3
 
 If a connection object is abandoned (it becomes unreachable), then it
-will vanish from pool.all automatically.  However, connections are
-involved in cycles, so exactly when a connection vanishes from pool.all
-isn't predictable.  It can be forced by running gc.collect():
+will vanish from pool.all automatically. However, connections are
+involved in cycles, so exactly when a connection vanishes from
+pool.all isn't predictable. It can be forced (on most platforms but
+not Jython) by running gc.collect():
 
-    >>> import gc
+    >>> import gc, sys
     >>> dummy = gc.collect()
     >>> len(pool.all)
     3
     >>> c3 = None
     >>> dummy = gc.collect()  # removes c3 from pool.all
-    >>> len(pool.all)
+    >>> len(pool.all) if not sys.platform.startswith("java") else 2
     2
 
 Note that c3 is really gone; in particular it didn't get added back to

--- a/src/ZODB/tests/testBroken.py
+++ b/src/ZODB/tests/testBroken.py
@@ -67,7 +67,7 @@ def test_integration():
     >>> conn3 = db.open()
     >>> a3 = conn3.root()['a']
     >>> a3  # doctest: +NORMALIZE_WHITESPACE
-    <persistent broken ZODB.not.there.Atall instance 
+    <persistent broken ZODB.not.there.Atall instance
         '\x00\x00\x00\x00\x00\x00\x00\x01'>
 
     >>> a3.__Broken_state__

--- a/src/ZODB/tests/testCache.py
+++ b/src/ZODB/tests/testCache.py
@@ -32,7 +32,6 @@ import unittest
 import ZODB
 import ZODB.MappingStorage
 import ZODB.tests.util
-from ZODB.tests.util import PYPY
 
 PY2 = sys.version_info[0] == 2
 
@@ -191,7 +190,6 @@ class DBMethods(CacheTestBase):
 
 class LRUCacheTests(CacheTestBase):
 
-    @unittest.skipIf(PYPY, "Implementation details of the PickleCache")
     def testLRU(self):
         # verify the LRU behavior of the cache
         dataset_size = 5

--- a/src/ZODB/tests/testCache.py
+++ b/src/ZODB/tests/testCache.py
@@ -32,6 +32,7 @@ import unittest
 import ZODB
 import ZODB.MappingStorage
 import ZODB.tests.util
+from ZODB.tests.util import PYPY
 
 PY2 = sys.version_info[0] == 2
 
@@ -190,6 +191,7 @@ class DBMethods(CacheTestBase):
 
 class LRUCacheTests(CacheTestBase):
 
+    @unittest.skipIf(PYPY, "Implementation details of the PickleCache")
     def testLRU(self):
         # verify the LRU behavior of the cache
         dataset_size = 5
@@ -339,7 +341,10 @@ class CacheErrors(unittest.TestCase):
         def add(key, obj):
             self.cache[key] = obj
 
-        nones = sys.getrefcount(None)
+        # getrefcount is an implementation detail of CPython,
+        # not present under PyPy/Jython
+        rc = getattr(sys, 'getrefcount', lambda x: 1)
+        nones = rc(None)
 
         key = p64(2)
         # value isn't persistent
@@ -369,7 +374,7 @@ class CacheErrors(unittest.TestCase):
             # structure that adds a new reference to None for each executed
             # line of code, which interferes with this test.  So check it
             # only if we're running without coverage tracing.
-            self.assertEqual(sys.getrefcount(None), nones)
+            self.assertEqual(rc(None), nones)
 
     def testTwoCaches(self):
         jar2 = StubDataManager()

--- a/src/ZODB/tests/testConnection.py
+++ b/src/ZODB/tests/testConnection.py
@@ -244,10 +244,14 @@ class UserMethodTests(unittest.TestCase):
 
         If all references to the object are released, then a new
         object will be returned. The cache doesn't keep unreferenced
-        ghosts alive.  (The next object returned my still have the
-        same id, because Python may re-use the same memory.)
+        ghosts alive, although on some implementations like PyPy we
+        need to run a garbage collection to be sure they go away. (The
+        next object returned my still have the same id, because Python
+        may re-use the same memory.)
 
         >>> del obj, obj2
+        >>> import gc
+        >>> _ = gc.collect()
         >>> cn._cache.get(p64(0), None)
 
         If the object is unghosted, then it will stay in the cache
@@ -683,8 +687,8 @@ def doctest_proper_ghost_initialization_with_empty__p_deactivate():
     >>> transaction.commit()
 
     >>> conn2 = db.open()
-    >>> conn2.root.x._p_changed
-
+    >>> bool(conn2.root.x._p_changed)
+    False
     >>> conn2.root.x.y
     1
 

--- a/src/ZODB/tests/testConnection.py
+++ b/src/ZODB/tests/testConnection.py
@@ -246,7 +246,7 @@ class UserMethodTests(unittest.TestCase):
         object will be returned. The cache doesn't keep unreferenced
         ghosts alive, although on some implementations like PyPy we
         need to run a garbage collection to be sure they go away. (The
-        next object returned my still have the same id, because Python
+        next object returned may still have the same id, because Python
         may re-use the same memory.)
 
         >>> del obj, obj2

--- a/src/ZODB/tests/testConnectionSavepoint.py
+++ b/src/ZODB/tests/testConnectionSavepoint.py
@@ -99,6 +99,7 @@ one traditional use for savepoints is simply to free memory space midstream
 during a long transaction.  Before ZODB 3.4.2, making a savepoint failed
 to trigger cache gc, and this test verifies that it now does.
 
+    >>> import gc
     >>> import ZODB
     >>> from ZODB.tests.MinPO import MinPO
     >>> from ZODB.MappingStorage import MappingStorage
@@ -129,6 +130,13 @@ Making a savepoint at this time used to leave the cache holding the same
 number of objects.  Make sure the cache shrinks now instead.
 
     >>> dummy = transaction.savepoint()
+
+Jython needs a GC, and needs to actually access the map to be sure the size
+is updated:
+
+    >>> _ = gc.collect()
+    >>> _ = getattr(cn._cache, 'data', {}).values()
+    >>> _ = getattr(cn._cache, 'data', {}).keys()
     >>> len(cn._cache) <= CACHESIZE + 1
     True
 

--- a/src/ZODB/tests/testConnectionSavepoint.py
+++ b/src/ZODB/tests/testConnectionSavepoint.py
@@ -131,8 +131,9 @@ number of objects.  Make sure the cache shrinks now instead.
 
     >>> dummy = transaction.savepoint()
 
-Jython needs a GC, and needs to actually access the map to be sure the size
-is updated:
+Jython needs a GC, and needs to actually access the cache data to be
+sure the size is updated (it uses "eventually consistent" implementations for
+its weak dictionaries):
 
     >>> _ = gc.collect()
     >>> _ = getattr(cn._cache, 'data', {}).values()

--- a/src/ZODB/tests/testConnectionSavepoint.txt
+++ b/src/ZODB/tests/testConnectionSavepoint.txt
@@ -112,10 +112,10 @@ If we provide entries that cause an unexpected error:
     ...     ('sally', 10.0),
     ...     ('bob',   '20.0'),
     ...     ('sally', 10.0),
-    ...     ])
+    ...     ]) #doctest: +ELLIPSIS
     Updated bob
     Updated sally
-    Unexpected exception unsupported operand type(s) for +=: 'float' and 'str'
+    Unexpected exception unsupported operand type(s) for +...: 'float' and 'str'
 
 Because the apply_entries used a savepoint for the entire function, it was
 able to rollback the partial changes without rolling back changes made in the
@@ -194,4 +194,3 @@ However, using a savepoint invalidates any savepoints that come after it:
     InvalidSavepointRollbackError: invalidated by a later savepoint
 
     >>> transaction.abort()
-

--- a/src/ZODB/tests/testDB.py
+++ b/src/ZODB/tests/testDB.py
@@ -125,7 +125,10 @@ def connectionDebugInfo():
     ...     now += .1
     ...     return now
     >>> real_time = time.time
-    >>> time.time = faux_time
+    >>> if isinstance(time,type):
+    ...    time.time = staticmethod(faux_time) # Jython
+    ... else:
+    ...     time.time = faux_time
 
     >>> from ZODB.tests.util import DB
     >>> import transaction

--- a/src/ZODB/tests/testDB.py
+++ b/src/ZODB/tests/testDB.py
@@ -252,7 +252,7 @@ if sys.version_info >= (2, 6):
 
         >>> with db.transaction() as conn2:
         ...     conn2.root()['y'] = 2
-        ...     XXX
+        ...     XXX #doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         ...
         NameError: name 'XXX' is not defined

--- a/src/ZODB/tests/testRecover.py
+++ b/src/ZODB/tests/testRecover.py
@@ -74,7 +74,7 @@ class RecoverTest(ZODB.tests.util.TestCase):
             # Note that we open the file as r+, not a+. Seeking a file
             # open in append mode is effectively a no-op *depending on
             # platform*, as the write may simply append to the file. An
-            # earlier version of this code opened the file is a+ mode,
+            # earlier version of this code opened the file in a+ mode,
             # meaning on some platforms it was only writing to the end of the
             # file, and so the test cases were always finding that bad data.
             # For compatibility with that, we do one write outside the loop

--- a/src/ZODB/tests/testSerialize.py
+++ b/src/ZODB/tests/testSerialize.py
@@ -140,7 +140,7 @@ class SerializerFunctestCase(unittest.TestCase):
         # so force it ourselves
         environ = os.environ.copy()
         if IS_JYTHON:
-            # Jython 2.7rc2 has a bug; if it's Lib directory is
+            # Jython 2.7rc2 has a bug; if its Lib directory is
             # specifically put on the PYTHONPATH, then it doesn't add
             # it itself, which means it fails to 'import site' because
             # it can't import '_jythonlib' and the whole process fails

--- a/src/ZODB/tests/testSerialize.py
+++ b/src/ZODB/tests/testSerialize.py
@@ -177,7 +177,6 @@ def _functest_load(fqn):
     # Open the database and attempt to deserialize the tree
     # (run in separate process)
     from ZODB import DB
-    import transaction
     WORKING, FAILING = _working_failing_datetimes()
     db = DB(fqn)
     conn = db.open()
@@ -186,7 +185,6 @@ def _functest_load(fqn):
         tree = root['tree']
         assert tree[WORKING] == 'working'
         assert tree[FAILING] == 'failing'
-        transaction.abort()
     finally: # Windoze
         conn.close()
         db.close()

--- a/src/ZODB/tests/testSerialize.py
+++ b/src/ZODB/tests/testSerialize.py
@@ -177,6 +177,7 @@ def _functest_load(fqn):
     # Open the database and attempt to deserialize the tree
     # (run in separate process)
     from ZODB import DB
+    import transaction
     WORKING, FAILING = _working_failing_datetimes()
     db = DB(fqn)
     conn = db.open()
@@ -185,6 +186,7 @@ def _functest_load(fqn):
         tree = root['tree']
         assert tree[WORKING] == 'working'
         assert tree[FAILING] == 'failing'
+        transaction.abort()
     finally: # Windoze
         conn.close()
         db.close()

--- a/src/ZODB/tests/test_cache.py
+++ b/src/ZODB/tests/test_cache.py
@@ -52,7 +52,7 @@ class RegularObject(Persistent):
 class PersistentObject(Persistent):
     pass
 
-class CacheTests(object):
+class CacheTests:
 
     def test_cache(self):
         r"""Test basic cache methods.

--- a/src/ZODB/tests/test_cache.py
+++ b/src/ZODB/tests/test_cache.py
@@ -14,8 +14,8 @@
 """Test behavior of Connection plus cPickleCache."""
 from persistent import Persistent
 from ZODB.config import databaseFromString
-import doctest
 import transaction
+import doctest
 
 class RecalcitrantObject(Persistent):
     """A Persistent object that will not become a ghost."""
@@ -52,7 +52,7 @@ class RegularObject(Persistent):
 class PersistentObject(Persistent):
     pass
 
-class CacheTests:
+class CacheTests(object):
 
     def test_cache(self):
         r"""Test basic cache methods.
@@ -199,12 +199,15 @@ class CacheTests:
         5
 
         >>> transaction.abort()
+        >>> len(cn._cache)
+        6
+        >>> cn._cache.cache_non_ghost_count
+        2
         >>> cn._cache.ringlen()
         2
         >>> RegularObject.deactivations
         4
         """
-
     def test_gc_on_open_connections(self):
         r"""Test that automatic GC is not applied to open connections.
 

--- a/src/ZODB/tests/test_fsdump.py
+++ b/src/ZODB/tests/test_fsdump.py
@@ -58,7 +58,7 @@ Trans #00000 tid=... time=... offset=<OFFSET>
 Trans #00001 tid=... time=... offset=<OFFSET>
     status=' ' user='' description='added an OOBTree'
   data #00000 oid=0000000000000000 size=<SIZE> class=persistent.mapping.PersistentMapping
-  data #00001 oid=0000000000000001 size=<SIZE> class=BTrees.OOBTree.OOBTree
+  data #00001 oid=0000000000000001 size=<SIZE> class=BTrees.OOBTree.OOBTree...
 
 Now we see two transactions and two changed objects.
 

--- a/src/ZODB/tests/testblob.py
+++ b/src/ZODB/tests/testblob.py
@@ -345,6 +345,18 @@ def gc_blob_removes_uncommitted_data():
     >>> os.path.exists(fname)
     True
     >>> file = blob = None
+
+    PyPy not being reference counted actually needs GC to be
+    explicitly requested. In experiments, it finds the weakref
+    on the first collection, but only does the cleanup on the second
+    collection:
+
+    >>> import gc
+    >>> _ = gc.collect()
+    >>> _ = gc.collect()
+
+    Now the file is gone on all platforms:
+
     >>> os.path.exists(fname)
     False
     """

--- a/src/ZODB/tests/testfsoids.py
+++ b/src/ZODB/tests/testfsoids.py
@@ -90,12 +90,12 @@ oid 0x00 persistent.mapping.PersistentMapping 2 revisions
         tid user=''
         tid description='added an OOBTree'
         new revision persistent.mapping.PersistentMapping at <OFFSET>
-        references 0x01 BTrees.OOBTree.OOBTree at <OFFSET>
-oid 0x01 BTrees.OOBTree.OOBTree 1 revision
+        references 0x01 BTrees.OOBTree.OOBTree... at <OFFSET>
+oid 0x01 BTrees.OOBTree.OOBTree... 1 revision
     tid 0x... offset=<OFFSET> ...
         tid user=''
         tid description='added an OOBTree'
-        new revision BTrees.OOBTree.OOBTree at <OFFSET>
+        new revision BTrees.OOBTree.OOBTree... at <OFFSET>
         referenced by 0x00 persistent.mapping.PersistentMapping at <OFFSET>
 
 So there are two revisions of oid 0 now, and the second references oid 1.
@@ -118,21 +118,21 @@ oid 0x00 persistent.mapping.PersistentMapping 2 revisions
         tid user=''
         tid description='added an OOBTree'
         new revision persistent.mapping.PersistentMapping at <OFFSET>
-        references 0x01 BTrees.OOBTree.OOBTree at <OFFSET>
+        references 0x01 BTrees.OOBTree.OOBTree... at <OFFSET>
     tid 0x... offset=<OFFSET> ...
         tid user=''
         tid description='circling back to the root'
-        referenced by 0x01 BTrees.OOBTree.OOBTree at <OFFSET>
-oid 0x01 BTrees.OOBTree.OOBTree 2 revisions
+        referenced by 0x01 BTrees.OOBTree.OOBTree... at <OFFSET>
+oid 0x01 BTrees.OOBTree.OOBTree... 2 revisions
     tid 0x... offset=<OFFSET> ...
         tid user=''
         tid description='added an OOBTree'
-        new revision BTrees.OOBTree.OOBTree at <OFFSET>
+        new revision BTrees.OOBTree.OOBTree... at <OFFSET>
         referenced by 0x00 persistent.mapping.PersistentMapping at <OFFSET>
     tid 0x... offset=<OFFSET> ...
         tid user=''
         tid description='circling back to the root'
-        new revision BTrees.OOBTree.OOBTree at <OFFSET>
+        new revision BTrees.OOBTree.OOBTree... at <OFFSET>
         references 0x00 persistent.mapping.PersistentMapping at <OFFSET>
 oid 0x02 <unknown> 0 revisions
     this oid was not defined (no data record for it found)

--- a/src/ZODB/tests/testpersistentclass.py
+++ b/src/ZODB/tests/testpersistentclass.py
@@ -55,10 +55,10 @@ def test_new_ghost_w_persistent_class():
     >>> import persistent
     >>> jar = object()
     >>> cache = persistent.PickleCache(jar, 10, 100)
-    >>> cache.new_ghost('1', PC)
+    >>> cache.new_ghost(b'1', PC)
 
-    >>> PC._p_oid
-    '1'
+    >>> PC._p_oid == b'1'
+    True
     >>> PC._p_jar is jar
     True
     >>> PC._p_serial
@@ -95,4 +95,3 @@ def test_suite():
 
 if __name__ == '__main__':
     unittest.main(defaultTest='test_suite')
-

--- a/src/ZODB/tests/util.py
+++ b/src/ZODB/tests/util.py
@@ -18,7 +18,6 @@ from ZODB.MappingStorage import DB
 import atexit
 import os
 import persistent
-import platform
 import re
 import sys
 import tempfile
@@ -184,18 +183,3 @@ def mess_with_time(test=None, globs=None, now=1278864701.5):
     zope.testing.setupstack.register(test, setattr, time, 'time', time.time)
 
     time.time = faux_time
-
-
-py_impl = getattr(platform, 'python_implementation', lambda: None)
-PYPY = py_impl() == 'PyPy'
-
-if not hasattr(unittest, 'skipIf'):
-    def skipIf(condition, reason):
-        if condition:
-            def skip(f):
-                return lambda self: None
-            return skip
-
-        def run(f):
-            return f
-        return run

--- a/src/ZODB/tests/util.py
+++ b/src/ZODB/tests/util.py
@@ -182,4 +182,7 @@ def mess_with_time(test=None, globs=None, now=1278864701.5):
     import time
     zope.testing.setupstack.register(test, setattr, time, 'time', time.time)
 
-    time.time = faux_time
+    if isinstance(time,type):
+        time.time = staticmethod(faux_time) # jython
+    else:
+        time.time = faux_time

--- a/src/ZODB/tests/util.py
+++ b/src/ZODB/tests/util.py
@@ -18,6 +18,7 @@ from ZODB.MappingStorage import DB
 import atexit
 import os
 import persistent
+import platform
 import re
 import sys
 import tempfile
@@ -184,3 +185,17 @@ def mess_with_time(test=None, globs=None, now=1278864701.5):
 
     time.time = faux_time
 
+
+py_impl = getattr(platform, 'python_implementation', lambda: None)
+PYPY = py_impl() == 'PyPy'
+
+if not hasattr(unittest, 'skipIf'):
+    def skipIf(condition, reason):
+        if condition:
+            def skip(f):
+                return lambda self: None
+            return skip
+
+        def run(f):
+            return f
+        return run

--- a/src/ZODB/utils.txt
+++ b/src/ZODB/utils.txt
@@ -41,7 +41,12 @@ To see this work (in a predictable way), we'll first hack time.time:
 
     >>> import time
     >>> old_time = time.time
-    >>> time.time = lambda : 1224825068.12
+    >>> time_value = 1224825068.12
+    >>> faux_time = lambda: time_value
+    >>> if isinstance(time,type):
+    ...    time.time = staticmethod(faux_time) # Jython
+    ... else:
+    ...     time.time = faux_time
 
 Now, if we ask for a new time stamp, we'll get one based on our faux
 time:
@@ -71,7 +76,7 @@ Here, since we called it at the same time, we got a time stamp that
 was only slightly larger than the previos one.  Of course, at a later
 time, the time stamp we get will be based on the time:
 
-    >>> time.time = lambda : 1224825069.12
+    >>> time_value = 1224825069.12
     >>> tid = ZODB.utils.newTid(tid2)
     >>> print(ZODB.TimeStamp.TimeStamp(tid))
     2008-10-24 05:11:09.120000
@@ -194,4 +199,4 @@ supports optional method preconditions [1]_.
    locked.  Combining preconditions with locking provides both
    efficiency and concise expressions.  A more general-purpose
    facility would almost certainly provide separate descriptors for
-   preconditions. 
+   preconditions.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,pypy,simple
+envlist = py26,py27,py32,py33,py34,pypy,simple,pypy3
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,7 @@
 [tox]
+# Jython 2.7rc2 does work, but unfortunately has an issue running
+# with Tox 1.9.2 (http://bugs.jython.org/issue2325)
+#envlist = py26,py27,py32,py33,py34,pypy,simple,jython,pypy3
 envlist = py26,py27,py32,py33,py34,pypy,simple,pypy3
 
 [testenv]
@@ -28,6 +31,10 @@ basepython =
 commands =
     python setup.py test -q
 deps = {[testenv]deps}
+
+[testenv:jython]
+commands =
+   jython setup.py test -q
 
 [testenv:coverage]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -32,10 +32,6 @@ commands =
     python setup.py test -q
 deps = {[testenv]deps}
 
-[testenv:jython]
-commands =
-   jython setup.py test -q
-
 [testenv:coverage]
 basepython = python2.7
 usedevelop = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,simple
+envlist = py26,py27,py32,py33,py34,pypy,simple
 
 [testenv]
 commands =


### PR DESCRIPTION
Fixes #33. Depends on persistent 4.1.0. Also supports jython, though you have to run the tests manually so that's not mentioned.

Highlights of changes:

- Use zodbpickle under not just PyPy but Python2.7. This fixes the broken `noload` problem that's encountered by many of the tools and things like relstorage and zc.zodbdgc.
- Centralize the creation of picklers and unpicklers, smoothing over the differences between Python versions and zodbpickle. This takes care of an existing TODO.
- The Blob class needs to use an external weakref, not one stored on `self`. See https://bitbucket.org/pypy/pypy/issue/2030/circular-weakref-callbacks-never-called

Other than that, the changes are pretty minor and mostly in doctests.