### PR TITLE
Make zodbpickle non-optional. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
     - 3.3
     - 3.4
 install:
-    - travis_retry pip install BTrees ZConfig manuel persistent six transaction zc.lockfile zdaemon zope.interface zope.testing zope.testrunner
+    - travis_retry pip install BTrees ZConfig manuel persistent six transaction zc.lockfile zdaemon zodbpickle zope.interface zope.testing zope.testrunner
     - travis_retry pip install -e .
 script:
     - zope-testrunner -u --test-path=src --auto-color --auto-progress

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@
 4.2.1 (unreleased)
 ==================
 
-- TBD
+- Make the ``zodbpickle`` dependency required and not conditional.
+  This fixes various packaging issues involving pip and its wheel
+  cache. zodbpickle was only optional under Python 2.6 so this change
+  only impacts users of that version.
 
 4.2.0 (2015-06-02)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,6 @@ setup(name="ZODB",
       tests_require = tests_require,
       extras_require = {
         'test': tests_require,
-        ':python_version != "2.6"': ['zodbpickle >= 0.6.0'],
       },
       install_requires = [
         'persistent >= 4.1.0',
@@ -164,6 +163,7 @@ setup(name="ZODB",
         'zc.lockfile',
         'zdaemon >= 4.0.0a1',
         'zope.interface',
+        'zodbpickle >= 0.6.0',
       ],
       zip_safe = False,
       entry_points = """

--- a/src/ZODB/_compat.py
+++ b/src/ZODB/_compat.py
@@ -12,20 +12,20 @@
 #
 ##############################################################################
 import sys
+from six import PY3
 
 IS_JYTHON = sys.platform.startswith('java')
 
-try:
+
+if not PY3:
     # Python 2.x
-    import cPickle
-    if ((hasattr(cPickle.Unpickler, 'load') and not hasattr(cPickle.Unpickler, 'noload')) or
-		sys.version_info >= (2,7)):
-        # PyPy doesn't have noload, and noload is broken in Python 2.7.
-        # Get the fastest version we can (PyPy has no fastpickle)
-        try:
-            import zodbpickle.fastpickle as cPickle
-        except ImportError:
-            import zodbpickle.pickle as cPickle
+    # PyPy's cPickle doesn't have noload, and noload is broken in Python 2.7,
+    # so we need zodbpickle.
+    # Get the fastest working version we can (PyPy has no fastpickle)
+    try:
+        import zodbpickle.fastpickle as cPickle
+    except ImportError:
+        import zodbpickle.pickle as cPickle
     Pickler = cPickle.Pickler
     Unpickler = cPickle.Unpickler
     dump = cPickle.dump
@@ -36,7 +36,7 @@ try:
     NAME_MAPPING = {}
     _protocol = 1
     FILESTORAGE_MAGIC = b"FS21"
-except ImportError:
+else:
     # Python 3.x: can't use stdlib's pickle because
     # http://bugs.python.org/issue6784
     import zodbpickle.pickle

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps =
     transaction
     zc.lockfile
     zdaemon
+    zodbpickle
     zope.interface
     zope.testing
     zope.testrunner >= 4.4.6


### PR DESCRIPTION
As [discussed on the mailing list](https://groups.google.com/forum/#!topic/zodb/dRP-AGS7hmQ). Ref #36 and #37 

The only potential compatibility issue I'm aware of for Python 2.6 users is the [change in exceptions that are raised](https://github.com/zopefoundation/ZODB/issues/36#issuecomment-108438240). I wasn't sure if/where to mention that. 

Arguably this should be a bigger version bump than just 4.2.1 but I didn't change that either.