### PR TITLE
Cleanup tox.ini and .travis.yml as mentioned in #42 (and Python 3.5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
     - 3.2
     - 3.3
     - 3.4
+    - 3.5
 install:
     # First install a newer pip so that it can use the wheel cache
     # (only needed until travis upgrades pip to 7.x; note that the 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,25 @@ python:
     - 3.3
     - 3.4
 install:
-    - travis_retry pip install BTrees ZConfig manuel persistent six transaction zc.lockfile zdaemon zodbpickle zope.interface zope.testing zope.testrunner
-    - travis_retry pip install -e .
+    # First install a newer pip so that it can use the wheel cache
+    # (only needed until travis upgrades pip to 7.x; note that the 3.5
+    # environment uses pip 7.1 by default).
+    - travis_retry pip install -U pip
+    # A newer wheel is also needed under Python 3, but only after we have
+    # a newer pip to take advantage of the cache.
+    - travis_retry pip install -U wheel
+    # Then start installing our deps so they can be cached. Note that use of --build-options / --global-options / --install-options
+    # disables the cache.
+    - travis_retry pip install -U manuel zope.testing zope.testrunner
+    - travis_retry pip install -U -e .
 script:
     - zope-testrunner -u --test-path=src --auto-color --auto-progress
     - zope-testrunner -f --test-path=src --auto-color --auto-progress
 notifications:
     email: false
+# cache: pip seems not to work if `install` is replaced (https://github.com/travis-ci/travis-ci/issues/3239)
+cache:
+  directories:
+    - $HOME/.cache/pip
+before_cache:
+    - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Change History
 ================
 
-4.2.1 (unreleased)
+4.3.0 (unreleased)
 ==================
 
 - Make the ``zodbpickle`` dependency required and not conditional.
@@ -10,6 +10,8 @@
   cache. zodbpickle was only optional under Python 2.6 so this change
   only impacts users of that version.  See
   https://github.com/zopefoundation/ZODB/pull/42.
+
+- Add support for Python 3.5.
 
 4.2.0 (2015-06-02)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ to application logic.  ZODB includes features such as a plugable storage
 interface, rich transaction support, and undo.
 """
 
-version = "4.2.1.dev0"
+version = "4.3.0.dev0"
 
 import os
 import sys
@@ -52,6 +52,7 @@ Programming Language :: Python :: 3
 Programming Language :: Python :: 3.2
 Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
+Programming Language :: Python :: 3.5
 Programming Language :: Python :: Implementation :: CPython
 Programming Language :: Python :: Implementation :: PyPy
 Topic :: Database
@@ -156,7 +157,7 @@ setup(name="ZODB",
       },
       install_requires = [
         'persistent >= 4.1.0',
-        'BTrees >= 4.1.3',
+        'BTrees >= 4.2.0',
         'ZConfig',
         'transaction >= 1.4.4',
         'six',

--- a/tox.ini
+++ b/tox.ini
@@ -12,16 +12,7 @@ commands =
     zope-testrunner -f --test-path=src --auto-color --auto-progress
 # without explicit deps, setup.py test will download a bunch of eggs into $PWD
 deps =
-    BTrees
-    ZConfig
     manuel
-    persistent
-    six
-    transaction
-    zc.lockfile
-    zdaemon
-    zodbpickle
-    zope.interface
     zope.testing
     zope.testrunner >= 4.4.6
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # Jython 2.7rc2 does work, but unfortunately has an issue running
 # with Tox 1.9.2 (http://bugs.jython.org/issue2325)
 #envlist = py26,py27,py32,py33,py34,pypy,simple,jython,pypy3
-envlist = py26,py27,py32,py33,py34,pypy,simple,pypy3
+envlist = py26,py27,py32,py33,py34,py35,pypy,simple,pypy3
 
 [testenv]
 commands =


### PR DESCRIPTION
- (Both) Remove repetition of deps. Only install tests_require deps
  explicitly. The previous comment in tox.ini about eggs in the
  working directory doesn't apply, per @mgedmin.
- Setup Travis to use the local wheel cache for faster install times. I stole this from what I do in gevent, which works, but may not be optimal.