### PR TITLE
Fixing uncaught exception problem on shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ include
 build
 *.so
 parts
+*.pyc
+.eggs
+*.egg-info

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -18,7 +18,9 @@ Bugs Fixed
 - Pinned the ``transaction`` and ``manuel`` dependencies to Python 2.5-
   compatible versions when installing under Python 2.5.
 
-- Cleanup of nested mvcc connections could have failed.
+- Avoid failure during cleanup of nested databases that provide MVCC
+  on storage level (Relstorage).
+  https://github.com/zopefoundation/ZODB/issues/45
 
 3.10.5 (2011-11-19)
 ===================

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -18,6 +18,8 @@ Bugs Fixed
 - Pinned the ``transaction`` and ``manuel`` dependencies to Python 2.5-
   compatible versions when installing under Python 2.5.
 
+- Cleanup of nested mvcc connections could have failed.
+
 3.10.5 (2011-11-19)
 ===================
 

--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -1073,7 +1073,8 @@ class Connection(ExportImport, object):
     def _release_resources(self):
         for c in self.connections.itervalues():
             if c._mvcc_storage:
-                c._storage.release()
+                if c._storage is not None:
+                    c._storage.release()
             c._storage = c._normal_storage = None
             c._cache = PickleCache(self, 0, 0)
 

--- a/src/ZODB/tests/testMVCCMappingStorage.py
+++ b/src/ZODB/tests/testMVCCMappingStorage.py
@@ -33,6 +33,15 @@ from ZODB.tests import (
     )
 
 class MVCCTests:
+    def checkClosingNestedDatabasesWorks(self):
+        # This tests for the error described in
+        # https://github.com/zopefoundation/ZODB/issues/45
+        db1 = DB(self._storage)
+        db2 = DB(None, databases=db1.databases, database_name='2')
+        db1.open().get_connection('2')
+        db1.close()
+        db2.close()
+
 
     def checkCrossConnectionInvalidation(self):
         # Verify connections see updated state at txn boundaries.
@@ -122,7 +131,7 @@ class MVCCTests:
             self.assert_(r2['gamma']['delta'] == 'yes')
         finally:
             db.close()
-    
+
 
 class MVCCMappingStorageTests(
     StorageTestBase.StorageTestBase,


### PR DESCRIPTION
Nested connections try to clean up themselves multiple
times. This does not work.

I'd like to have a review from somebody, I don't feel 1000 % confident about the change.