### PR TITLE
Drop support for Python 2.6 / 3.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ sudo: false
 python:
     - pypy
     - pypy3
-    - 2.6
     - 2.7
-    - 3.2
     - 3.3
     - 3.4
     - 3.5

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 4.3.0 (unreleased)
 ==================
 
+- Drop support for Python 2.6 and 3.2.
+
 - Make the ``zodbpickle`` dependency required and not conditional.
   This fixes various packaging issues involving pip and its wheel
   cache. zodbpickle was only optional under Python 2.6 so this change

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,8 @@ Intended Audience :: Developers
 License :: OSI Approved :: Zope Public License
 Programming Language :: Python
 Programming Language :: Python :: 2
-Programming Language :: Python :: 2.6
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.2
 Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 # Jython 2.7rc2 does work, but unfortunately has an issue running
 # with Tox 1.9.2 (http://bugs.jython.org/issue2325)
-#envlist = py26,py27,py32,py33,py34,pypy,simple,jython,pypy3
-envlist = py26,py27,py32,py33,py34,py35,pypy,simple,pypy3
+#envlist = py26,py27,py33,py34,pypy,simple,jython,pypy3
+envlist = py27,py33,py34,py35,pypy,simple,pypy3
 
 [testenv]
 commands =


### PR DESCRIPTION
3.2 is no longer supported by our packaging / CI tools.

2.6 is long out-of-support from Python devs.