### PR TITLE
patch time.time in historical_connections to avoid windows failures.

### DIFF
--- a/src/ZODB/DB.py
+++ b/src/ZODB/DB.py
@@ -274,7 +274,7 @@ class KeyedConnectionPool(AbstractConnectionPool):
             pool.map(f)
 
     def availableGC(self):
-        for key, pool in self.pools.items():
+        for key, pool in list(self.pools.items()):
             pool.availableGC()
             if not pool.all:
                 del self.pools[key]

--- a/src/ZODB/historical_connections.txt
+++ b/src/ZODB/historical_connections.txt
@@ -11,10 +11,16 @@ Historical Connections
     ...     return _now
     >>> import time
     >>> real_time_time = time.time
+    >>> real_time_sleep = time.sleep
+    >>> def faux_time_sleep(amt):
+    ...    global _now
+    ...    _now += amt
     >>> if isinstance(time,type):
     ...    time.time = staticmethod(faux_time_time) # Jython
+    ...    time.sleep = faux_time_sleep
     ... else:
     ...     time.time = faux_time_time
+    ...     time.sleep = faux_time_sleep
     >>> def utcnow():
     ...     return datetime.datetime.fromtimestamp(_now)
 
@@ -312,6 +318,7 @@ memory usage would also be brief and unlikely to overlap.
 .. restore time
 
     >>> time.time = real_time_time
+    >>> time.sleep = real_time_sleep
 
 .. ......... ..
 .. Footnotes ..

--- a/src/ZODB/historical_connections.txt
+++ b/src/ZODB/historical_connections.txt
@@ -15,6 +15,8 @@ Historical Connections
     ...    time.time = staticmethod(faux_time_time) # Jython
     ... else:
     ...     time.time = faux_time_time
+    >>> def utcnow():
+    ...     return datetime.datetime.fromtimestamp(_now)
 
 Usage
 =====
@@ -55,7 +57,7 @@ We wait for some time to pass, record he time, and then make some other changes.
     >>> time.sleep(.01)
 
     >>> import datetime
-    >>> now = datetime.datetime.utcnow()
+    >>> now = utcnow()
     >>> time.sleep(.01)
 
     >>> root = conn.root()
@@ -272,7 +274,7 @@ Note that if you try to open an historical connection to a time in the future,
 you will get an error.
 
     >>> historical_conn = db.open(
-    ...     at=datetime.datetime.utcnow()+datetime.timedelta(1))
+    ...     at=utcnow()+datetime.timedelta(1))
     Traceback (most recent call last):
     ...
     ValueError: cannot open an historical connection in the future.

--- a/src/ZODB/historical_connections.txt
+++ b/src/ZODB/historical_connections.txt
@@ -7,7 +7,7 @@ Historical Connections
     >>> _now = 1231019584.0
     >>> def faux_time_time():
     ...     global _now
-    ...     _now += .1
+    ...     _now += .001 # must be less than 0.01
     ...     return _now
     >>> import time
     >>> real_time_time = time.time

--- a/src/ZODB/historical_connections.txt
+++ b/src/ZODB/historical_connections.txt
@@ -2,6 +2,20 @@
 Historical Connections
 ======================
 
+.. We need to mess with time to prevent spurious test failures on windows
+
+    >>> now = 1231019584.0
+    >>> def faux_time_time():
+    ...     global now
+    ...     now += .1
+    ...     return now
+    >>> import time
+    >>> real_time_time = time.time
+    >>> if isinstance(time,type):
+    ...    time.time = staticmethod(faux_time_time) # Jython
+    ... else:
+    ...     time.time = faux_time_time
+
 Usage
 =====
 
@@ -292,6 +306,10 @@ memory usage would also be brief and unlikely to overlap.
 
     >>> db.close()
     >>> db2.close()
+
+.. restore time
+
+    >>> time.time = real_time_time
 
 .. ......... ..
 .. Footnotes ..

--- a/src/ZODB/historical_connections.txt
+++ b/src/ZODB/historical_connections.txt
@@ -4,11 +4,11 @@ Historical Connections
 
 .. We need to mess with time to prevent spurious test failures on windows
 
-    >>> now = 1231019584.0
+    >>> _now = 1231019584.0
     >>> def faux_time_time():
-    ...     global now
-    ...     now += .1
-    ...     return now
+    ...     global _now
+    ...     _now += .1
+    ...     return _now
     >>> import time
     >>> real_time_time = time.time
     >>> if isinstance(time,type):


### PR DESCRIPTION
Untested locally, copy-n-pasted from DemoStorage.test. Let's see what Travis says.