### PR TITLE
Fix possible data corruption after FileStorage is truncated to roll back a transaction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@
 - Remove useless dependency to `zdaemon` in setup.py. Remove ZEO documentation.
   Both were leftovers from the time where ZEO was part of this repository.
 
+- Fix possible data corruption after FileStorage is truncated to roll back a
+  transaction.
+  https://github.com/zopefoundation/ZODB/pull/52
+
 4.2.0 (2015-06-02)
 ==================
 

--- a/src/ZODB/tests/testFileStorage.py
+++ b/src/ZODB/tests/testFileStorage.py
@@ -25,6 +25,7 @@ import zope.testing.setupstack
 from ZODB import POSException
 from ZODB import DB
 from ZODB.fsIndex import fsIndex
+from ZODB.utils import U64, p64, z64
 
 from ZODB.tests import StorageTestBase, BasicStorage, TransactionalUndoStorage
 from ZODB.tests import PackableStorage, Synchronization, ConflictResolution
@@ -217,7 +218,6 @@ class FileStorageTests(
         # global.
         import time
 
-        from ZODB.utils import U64, p64
         from ZODB.FileStorage.format import CorruptedError
         from ZODB.serialize import referencesf
 
@@ -284,6 +284,27 @@ class FileStorageTests(
                 self.assertEqual(next_oid, None)
             else:
                 self.assertNotEqual(next_oid, None)
+
+    def checkFlushAfterTruncate(self, fail=False):
+        r0 = self._dostore(z64)
+        storage = self._storage
+        t = transaction.Transaction()
+        storage.tpc_begin(t)
+        storage.store(z64, r0, b'foo', b'', t)
+        storage.tpc_vote(t)
+        # Read operations are done with separate 'file' objects with their
+        # own buffers: here, the buffer also includes voted data.
+        storage.load(z64)
+        # This must invalidate all read buffers.
+        storage.tpc_abort(t)
+        self._dostore(z64, r0, b'bar', 1)
+        # In the case that read buffers were not invalidated, return value
+        # is based on what was cached during the first load.
+        self.assertEqual(storage.load(z64)[0], b'foo' if fail else b'bar')
+
+    def checkFlushNeededAfterTruncate(self):
+        self._storage._files.flush = lambda: None
+        self.checkFlushAfterTruncate(True)
 
 class FileStorageHexTests(FileStorageTests):
 


### PR DESCRIPTION
See the commit message for more information.
I wanted to attach the stress test I wrote to reproduce and understand the issue, but GitHub does not want *.py files. It was already sent to the mailing-list so you can find it there:
http://thread.gmane.org/gmane.comp.web.zope.zodb/12685/focus=12751

I'd like to also apply it on 3.10 branch.

/cc @vpelletier 