### PR TITLE
On Python 2 and Mac OS X, checkFlushAfterTruncate was failing.

### DIFF
--- a/src/ZODB/FileStorage/FileStorage.py
+++ b/src/ZODB/FileStorage/FileStorage.py
@@ -26,7 +26,6 @@ from struct import pack
 from struct import unpack
 
 from persistent.TimeStamp import TimeStamp
-from six import PY3
 from six import string_types as STRING_TYPES
 from zc.lockfile import LockFile
 from zope.interface import alsoProvides
@@ -2102,6 +2101,8 @@ class FilePool:
 
         This is required if they contain data of rolled back transactions.
         """
+        # Unfortunately, Python 3.x has no API to flush read buffers, and
+        # the API is ineffective in Python 2 on Mac OS X.
         with self.write_lock():
             self.empty()
 

--- a/src/ZODB/FileStorage/FileStorage.py
+++ b/src/ZODB/FileStorage/FileStorage.py
@@ -2103,12 +2103,7 @@ class FilePool:
         This is required if they contain data of rolled back transactions.
         """
         with self.write_lock():
-            if PY3:
-                # Unfortunately, Python 3.x has no API to flush read buffers.
-                self.empty()
-            else:
-                for f in self._files:
-                    f.flush()
+            self.empty()
 
     def close(self):
         with self._cond:


### PR DESCRIPTION
Changed to always empty the file pool.  I doubt that just flushing on
Python 2 was much of an optimization, and ... Python 2. :)