### PR TITLE
Fixed: FileStorage loadBefore didn't handle deleted/undone data correctly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@
 - DemoStorage: add support for conflict resolution and fix history()
   https://github.com/zopefoundation/ZODB/pull/58
 
+- Fixed: FileStorage loadBefore didn't handle deleted/undone data correctly.
+
 4.2.0 (2015-06-02)
 ==================
 

--- a/src/ZODB/FileStorage/FileStorage.py
+++ b/src/ZODB/FileStorage/FileStorage.py
@@ -489,11 +489,13 @@ class FileStorage(
                 if not pos:
                     return None
 
-            if h.back:
+            if h.plen:
+                return _file.read(h.plen), h.tid, end_tid
+            elif h.back:
                 data, _, _, _ = self._loadBack_impl(oid, h.back, _file=_file)
                 return data, h.tid, end_tid
             else:
-                return _file.read(h.plen), h.tid, end_tid
+                raise POSKeyError(oid)
 
     def store(self, oid, oldserial, data, version, transaction):
         if self._is_read_only:

--- a/src/ZODB/tests/TransactionalUndoStorage.py
+++ b/src/ZODB/tests/TransactionalUndoStorage.py
@@ -179,6 +179,10 @@ class TransactionalUndoStorage:
         info = self._storage.undoInfo()
         self._undo(info[2]['id'], [oid])
         self.assertRaises(KeyError, self._storage.load, oid, '')
+
+        # Loading current data via loadBefore should raise a POSKeyError too:
+        self.assertRaises(KeyError, self._storage.loadBefore, oid,
+                          b'\x7f\xff\xff\xff\xff\xff\xff\xff')
         self._iterate()
 
     def checkUndoCreationBranch2(self):


### PR DESCRIPTION
Note that this is needed for a ZEO PR.