### PR TITLE
Move load to imvcc storage

### DIFF
--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -230,7 +230,7 @@ class Connection(ExportImport, object):
         if obj is not None:
             return obj
 
-        p, _ = self._storage.load(oid, '')
+        p, _ = self._storage.load(oid)
         obj = self._reader.getGhost(p)
 
         # Avoid infiniate loop if obj tries to load its state before
@@ -755,7 +755,7 @@ class Connection(ExportImport, object):
                 raise
 
         try:
-            p, serial = self._storage.load(oid, '')
+            p, serial = self._storage.load(oid)
 
             self._load_count += 1
 
@@ -1100,7 +1100,7 @@ class TmpStore:
     def load(self, oid, version=''):
         pos = self.index.get(oid)
         if pos is None:
-            return self._storage.load(oid, '')
+            return self._storage.load(oid)
         self._file.seek(pos)
         h = self._file.read(8)
         oidlen = u64(h)

--- a/src/ZODB/DB.py
+++ b/src/ZODB/DB.py
@@ -448,7 +448,7 @@ class DB(object):
         try:
             try:
                 temp_storage.poll_invalidations()
-                temp_storage.load(z64, '')
+                temp_storage.load(z64)
             except KeyError:
                 # Create the database's root in the storage if it doesn't exist
                 from persistent.mapping import PersistentMapping

--- a/src/ZODB/ExportImport.py
+++ b/src/ZODB/ExportImport.py
@@ -48,7 +48,7 @@ class ExportImport:
                 continue
             done_oids[oid] = True
             try:
-                p, serial = load(oid, '')
+                p, serial = load(oid)
             except:
                 logger.debug("broken reference for oid %s", repr(oid),
                              exc_info=True)

--- a/src/ZODB/interfaces.py
+++ b/src/ZODB/interfaces.py
@@ -313,7 +313,7 @@ class IStorageWrapper(Interface):
         there would be so many that it would be inefficient to do so.
         """
 
-    def invalidate(transaction_id, oids, version=''):
+    def invalidate(transaction_id, oids):
         """Invalidate object ids committed by the given transaction
 
         The oids argument is an iterable of object identifiers.
@@ -549,34 +549,6 @@ class IStorage(Interface):
         """The approximate number of objects in the storage
 
         This is used soley for informational purposes.
-        """
-
-    def load(oid, version):
-        """Load data for an object id
-
-        NOTE: This method is deprecated and may be removed in the
-        future.  It is no longer used by ZODB, although it may still
-        be used in some tests or scripts.  Previously, there was a
-        requirement that load results be properly ordered with
-        invalidations so that at any point in time, clients have a
-        consistent view of what version of an object is current.  This
-        restriction has been relaxed and some storages will be
-        simplified as a result of the removal of this requirement.
-
-        An alternative to calling load is calling loadBefore passing
-        ZODB.utils.maxtid::
-
-            store.loadBefore(oid, ZODB.utils.maxtid)
-
-        The version argumement should always be an empty string. It
-        exists soley for backward compatibility with older storage
-        implementations.
-
-        A data record and serial are returned.  The serial is a
-        transaction identifier of the transaction that wrote the data
-        record.
-
-        A POSKeyError is raised if there is no record for the object id.
         """
 
     def loadBefore(oid, tid):
@@ -1092,6 +1064,16 @@ class IMVCCStorage(IStorage):
         If the force parameter is False, the storage may choose to
         ignore this call. By ignoring this call, a storage can reduce
         the frequency of database polls, thus reducing database load.
+        """
+
+    def load(oid):
+        """Load current data for an object id
+
+        A data record and serial are returned.  The serial is a
+        transaction identifier of the transaction that wrote the data
+        record.
+
+        A POSKeyError is raised if there is no record for the object id.
         """
 
 

--- a/src/ZODB/mvccadapter.py
+++ b/src/ZODB/mvccadapter.py
@@ -139,7 +139,7 @@ class MVCCAdapterInstance(Base):
                 self._invalidations.clear()
                 return result
 
-    def load(self, oid, version=''):
+    def load(self, oid):
         assert self._start is not None
         r = self._storage.loadBefore(oid, self._start)
         if r is None:

--- a/src/ZODB/mvccadapter.py
+++ b/src/ZODB/mvccadapter.py
@@ -75,7 +75,7 @@ class MVCCAdapter(Base):
             for instance in self._instances:
                 instance._invalidateCache()
 
-    def invalidate(self, transaction_id, oids, version=''):
+    def invalidate(self, transaction_id, oids):
         with self._lock:
             for instance in self._instances:
                 instance._invalidate(oids)


### PR DESCRIPTION
This relatively small cleanup PR moves load to IMVCCStorage from IStorage.

It also loses the version argument from load and from IStorageWrapper.invalidate.
