### PR TITLE
Modernize and cleanup locking

### DIFF
--- a/src/ZODB/ActivityMonitor.py
+++ b/src/ZODB/ActivityMonitor.py
@@ -41,18 +41,15 @@ class ActivityMonitor:
         self.trim(now)
 
     def trim(self, now):
-        self.trim_lock.acquire()
-
-        log = self.log
-        cutoff = now - self.history_length
-        n = 0
-        loglen = len(log)
-        while n < loglen and log[n][0] < cutoff:
-            n = n + 1
-        if n:
-            del log[:n]
-
-        self.trim_lock.release()
+        with self.trim_lock:
+            log = self.log
+            cutoff = now - self.history_length
+            n = 0
+            loglen = len(log)
+            while n < loglen and log[n][0] < cutoff:
+                n = n + 1
+            if n:
+                del log[:n]
 
     def setHistoryLength(self, history_length):
         self.history_length = history_length

--- a/src/ZODB/FileStorage/FileStorage.py
+++ b/src/ZODB/FileStorage/FileStorage.py
@@ -747,7 +747,7 @@ class FileStorage(
                 finally:
                     self._ude = None
                     self._transaction = None
-                    self._commit_lock_release()
+                    self._commit_lock.release()
 
     def _finish(self, tid, u, d, e):
         # If self._nextpos is 0, then the transaction didn't write any
@@ -918,8 +918,8 @@ class FileStorage(
                     us.search()
                 # Give another thread a chance, so that a long undoLog()
                 # operation doesn't block all other activity.
-                self._lock_release()
-                self._lock_acquire()
+                self._lock.release()
+                self._lock.acquire()
             return us.results
 
     def undo(self, transaction_id, transaction):
@@ -1153,13 +1153,13 @@ class FileStorage(
             # blobs and removing the .old file (see further down).
 
             if self.blob_dir:
-                self._commit_lock_release()
+                self._commit_lock.release()
                 have_commit_lock = False
                 self._remove_blob_files_tagged_for_removal_during_pack()
 
         finally:
             if have_commit_lock:
-                self._commit_lock_release()
+                self._commit_lock.release()
             with self._lock:
                 self._pack_is_in_progress = False
 
@@ -1195,14 +1195,14 @@ class FileStorage(
 
             removed = False
             if level:
-                self._lock_acquire()
+                self._lock.acquire()
             try:
                 if not os.listdir(path):
                     os.rmdir(path)
                     removed = True
             finally:
                 if level:
-                    self._lock_release()
+                    self._lock.release()
 
             if removed:
                 maybe_remove_empty_dir_containing(path, level+1)

--- a/src/ZODB/FileStorage/interfaces.py
+++ b/src/ZODB/FileStorage/interfaces.py
@@ -30,7 +30,6 @@ class IFileStoragePacker(zope.interface.Interface):
         or, of the form:
 
            oid.encode('hex')+'\n'
-        
 
         If packing is unnecessary, or would not change the file, then
         no pack or removed files are created None is returned,
@@ -47,7 +46,7 @@ class IFileStoragePacker(zope.interface.Interface):
         - Rename the .pack file, and
 
         - process the blob_dir/.removed file by removing the blobs
-          corresponding to the file records.        
+          corresponding to the file records.
         """
 
 class IFileStorage(zope.interface.Interface):
@@ -60,14 +59,10 @@ class IFileStorage(zope.interface.Interface):
         "The file object used to access the underlying data."
         )
 
-    def _lock_acquire():
-        "Acquire the storage lock"
+    _lock = zope.interface.Attribute(
+        "The storage lock."
+        )
 
-    def _lock_release():
-        "Release the storage lock"
-
-    def _commit_lock_acquire():
-        "Acquire the storage commit lock"
-
-    def _commit_lock_release():
-        "Release the storage commit lock"
+    _commit_lock = zope.interface.Attribute(
+        "The storage commit lock."
+        )

--- a/src/ZODB/MappingStorage.py
+++ b/src/ZODB/MappingStorage.py
@@ -39,9 +39,7 @@ class MappingStorage(object):
         self._transactions = BTrees.OOBTree.OOBTree() # {tid->TransactionRecord}
         self._ltid = ZODB.utils.z64
         self._last_pack = None
-        _lock = ZODB.utils.RLock()
-        self._lock_acquire = _lock.acquire
-        self._lock_release = _lock.release
+        self._lock = ZODB.utils.RLock()
         self._commit_lock = ZODB.utils.Lock()
         self._opened = True
         self._transaction = None
@@ -269,9 +267,9 @@ class MappingStorage(object):
         if transaction is self._transaction:
             raise ZODB.POSException.StorageTransactionError(
                 "Duplicate tpc_begin calls for same transaction")
-        self._lock_release()
+        self._lock.release()
         self._commit_lock.acquire()
-        self._lock_acquire()
+        self._lock.acquire()
         self._transaction = transaction
         self._tdata = {}
         if tid is None:

--- a/src/ZODB/scripts/zodbload.py
+++ b/src/ZODB/scripts/zodbload.py
@@ -188,8 +188,7 @@ class MBox:
         self._max = max
 
     def next(self):
-        self._lock.acquire()
-        try:
+        with self.lock:
             if self._max > 0 and self.number >= self._max:
                 raise IndexError(self.number + 1)
             message = next(self._mbox)
@@ -199,8 +198,6 @@ class MBox:
             message.number = self.number
             message.mbox = self.__name__
             return message
-        finally:
-            self._lock.release()
 
 bins = 9973
 #bins = 11

--- a/src/ZODB/tests/testDemoStorage.py
+++ b/src/ZODB/tests/testDemoStorage.py
@@ -171,7 +171,7 @@ def testSomeDelegation():
     ...         six.print_(self.name, 'closed')
     ...     sortKey = __len__ = getTid = None
     ...     tpc_finish = tpc_vote = tpc_transaction = None
-    ...     _lock_acquire = _lock_release = lambda self: None
+    ...     _lock = ZODB.utils.Lock()
     ...     getName = lambda self: 'S'
     ...     isReadOnly = tpc_transaction = None
     ...     supportsUndo = undo = undoLog = undoInfo = None
@@ -196,6 +196,8 @@ def testSomeDelegation():
     >>> storage.tpc_begin(1, 2, 3)
     begin 2 3
     >>> storage.tpc_abort(1)
+
+    >>> 
 
     """
 

--- a/src/ZODB/tests/test_storage.py
+++ b/src/ZODB/tests/test_storage.py
@@ -99,13 +99,10 @@ class MinimalMemoryStorage(BaseStorage, object):
         del self._txn
 
     def _finish(self, tid, u, d, e):
-        self._lock_acquire()
-        try:
+        with self._lock:
             self._index.update(self._txn.index)
             self._cur.update(self._txn.cur())
             self._ltid = self._tid
-        finally:
-            self._lock_release()
 
     def loadBefore(self, the_oid, the_tid):
         # It's okay if loadBefore() is really expensive, because this

--- a/src/ZODB/utils.py
+++ b/src/ZODB/utils.py
@@ -286,8 +286,7 @@ class Locked(object):
             inst = args[0]
         func = self.__func__.__get__(self.__self__, self.__self_class__)
 
-        inst._lock_acquire()
-        try:
+        with inst._lock:
             for precondition in self.preconditions:
                 if not precondition(inst):
                     raise AssertionError(
@@ -295,8 +294,6 @@ class Locked(object):
                         precondition.__doc__.strip())
 
             return func(*args, **kw)
-        finally:
-            inst._lock_release()
 
 class locked(object):
 

--- a/src/ZODB/utils.py
+++ b/src/ZODB/utils.py
@@ -268,6 +268,12 @@ def mktemp(dir=None, prefix='tmp'):
     os.close(handle)
     return filename
 
+def check_precondition(precondition):
+    if not precondition():
+        raise AssertionError(
+            "Failed precondition: ",
+            precondition.__doc__.strip())
+
 class Locked(object):
 
     def __init__(self, func, inst=None, class_=None, preconditions=()):

--- a/src/ZODB/utils.txt
+++ b/src/ZODB/utils.txt
@@ -98,6 +98,10 @@ we'll create a "lock" type that simply prints when it is called:
     ...         print('acquire')
     ...     def release(self):
     ...         print('release')
+    ...     def __enter__(self):
+    ...         return self.acquire()
+    ...     def __exit__(self, *ignored):
+    ...         return self.release()
 
 Now we'll demonstrate the descriptor:
 
@@ -150,9 +154,7 @@ supports optional method preconditions [1]_.
 
     >>> class C:
     ...     def __init__(self):
-    ...         _lock = Lock()
-    ...         self._lock_acquire = _lock.acquire
-    ...         self._lock_release = _lock.release
+    ...         self._lock = Lock()
     ...         self._opened = True
     ...         self._transaction = None
     ...


### PR DESCRIPTION
- Move from try/finally to with

- Start phasing out the _lock_acquire/_lock_release shortcuts

- Replace simpler @locked decorators with with statements.

  I've come to prefer the with style tp the decorator style.
  I think it's clearer.

  (The decorators preceeded the Python with statement.)

  I left the decorators in cases where they were used with preconditions.

This is mostly pretty mechanical, although it got a little delicate in
places and ... tests