### PR TITLE
Test that IMultiCommitStorages are supported

### DIFF
--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -794,7 +794,7 @@ class Connection(ExportImport, object):
             raise
 
         if s:
-            if type(s[0]) is bytes:
+            if type(next(iter(s))) is bytes:
                 for oid in s:
                     self._handle_serial(oid)
                 return

--- a/src/ZODB/DB.py
+++ b/src/ZODB/DB.py
@@ -1012,8 +1012,8 @@ class TransactionalUndo(object):
     def tpc_vote(self, transaction):
         result = self._storage.tpc_vote(transaction)
         if result:
-            if isinstance(result[0], bytes):
-                self._oids.update(set(result))
+            if isinstance(next(iter(result)), bytes):
+                self._oids.update(result)
             else:
                 for oid, _ in result:
                     self._oids.add(oid)

--- a/src/ZODB/DB.py
+++ b/src/ZODB/DB.py
@@ -1010,8 +1010,13 @@ class TransactionalUndo(object):
                 self._oids.update(result[1])
 
     def tpc_vote(self, transaction):
-        for oid, _ in  self._storage.tpc_vote(transaction) or ():
-            self._oids.add(oid)
+        result = self._storage.tpc_vote(transaction)
+        if result:
+            if isinstance(result[0], bytes):
+                self._oids.update(set(result))
+            else:
+                for oid, _ in result:
+                    self._oids.add(oid)
 
     def tpc_finish(self, transaction):
         self._storage.tpc_finish(

--- a/src/ZODB/interfaces.py
+++ b/src/ZODB/interfaces.py
@@ -948,7 +948,7 @@ class IStorageUndoable(IStorage):
         This method must only be called in the first phase of
         two-phase commit (after tpc_begin but before tpc_vote). It
         returns a serial (transaction id) and a sequence of object ids
-        for objects affected by the transaction.
+        for objects affected by the transaction. It may also return None.
 
         """
         # Used by DB (Actually, by TransactionalUndo)

--- a/src/ZODB/multicommitadapter.py
+++ b/src/ZODB/multicommitadapter.py
@@ -11,7 +11,7 @@ class MultiCommitAdapter:
         self._storage = storage
         ifaces = zope.interface.providedBy(storage)
         zope.interface.alsoProvides(self, ifaces)
-        self._resolved = set()
+        self._resolved = set() # {OID}, here to make linters happy
 
     def __getattr__(self, name):
         v = getattr(self._storage, name)
@@ -39,7 +39,7 @@ class MultiCommitAdapter:
     def undo(self, transaction_id, transaction):
         r = self._storage.undo(transaction_id, transaction)
         if r:
-            self._resolved.update(set(r[1]))
+            self._resolved.update(r[1])
 
     def tpc_vote(self, *args):
         s = self._storage.tpc_vote(*args)
@@ -47,7 +47,7 @@ class MultiCommitAdapter:
             if serial == ResolvedSerial:
                 self._resolved.add(oid)
 
-        return list(self._resolved)
+        return self._resolved
 
     def tpc_finish(self, transaction, f=lambda tid: None):
 

--- a/src/ZODB/multicommitadapter.py
+++ b/src/ZODB/multicommitadapter.py
@@ -1,0 +1,65 @@
+"""Adapt non-IMultiCommitStorage storages to IMultiCommitStorage
+"""
+
+import zope.interface
+
+from .ConflictResolution import ResolvedSerial
+
+class MultiCommitAdapter:
+
+    def __init__(self, storage):
+        self._storage = storage
+        ifaces = zope.interface.providedBy(storage)
+        zope.interface.alsoProvides(self, ifaces)
+        self._resolved = set()
+
+    def __getattr__(self, name):
+        v = getattr(self._storage, name)
+        self.__dict__[name] = v
+        return v
+
+    def tpc_begin(self, *args):
+        self._storage.tpc_begin(*args)
+        self._resolved = set()
+
+    def store(self, oid, *args):
+        if self._storage.store(oid, *args) == ResolvedSerial:
+            self._resolved.add(oid)
+
+    def storeBlob(self, oid, *args):
+        s = self._storage.storeBlob(oid, *args)
+        if s:
+            if isinstance(s, bytes):
+                s = ((oid, s), )
+
+            for oid, serial in s:
+                if s == ResolvedSerial:
+                    self._resolved.add(oid)
+
+    def undo(self, transaction_id, transaction):
+        r = self._storage.undo(transaction_id, transaction)
+        if r:
+            self._resolved.update(set(r[1]))
+
+    def tpc_vote(self, *args):
+        s = self._storage.tpc_vote(*args)
+        for (oid, serial) in (s or ()):
+            if serial == ResolvedSerial:
+                self._resolved.add(oid)
+
+        return list(self._resolved)
+
+    def tpc_finish(self, transaction, f=lambda tid: None):
+
+        t = []
+
+        def func(tid):
+            t.append(tid)
+            f(tid)
+
+        self._storage.tpc_finish(transaction, func)
+
+        return t[0]
+
+    def __len__(self):
+        return len(self._storage)

--- a/src/ZODB/tests/TransactionalUndoStorage.py
+++ b/src/ZODB/tests/TransactionalUndoStorage.py
@@ -111,7 +111,12 @@ class TransactionalUndoStorage:
             undo_result = self._storage.undo(tid, t)
             if undo_result:
                 oids.extend(undo_result[1])
-        oids.extend(oid for (oid, _) in self._storage.tpc_vote(t) or ())
+        v = self._storage.tpc_vote(t)
+        if v:
+            if isinstance(v[0], bytes):
+                oids.extend(v)
+            else:
+                oids.extend(oid for (oid, _) in v)
         return oids
 
     def undo(self, tid, note):

--- a/src/ZODB/tests/TransactionalUndoStorage.py
+++ b/src/ZODB/tests/TransactionalUndoStorage.py
@@ -113,7 +113,7 @@ class TransactionalUndoStorage:
                 oids.extend(undo_result[1])
         v = self._storage.tpc_vote(t)
         if v:
-            if isinstance(v[0], bytes):
+            if isinstance(next(iter(v)), bytes):
                 oids.extend(v)
             else:
                 oids.extend(oid for (oid, _) in v)

--- a/src/ZODB/tests/blob_transaction.txt
+++ b/src/ZODB/tests/blob_transaction.txt
@@ -411,11 +411,6 @@ Similarly, the new object wasn't added to the storage:
     ...
     POSKeyError: 0x...
 
-    >>> blob_storage.loadBlob(blob._p_oid, s2)
-    Traceback (most recent call last):
-    ...
-    POSKeyError: 'No blob file at <BLOB STORAGE PATH>'
-
 .. clean up
 
     >>> tm1.abort()

--- a/src/ZODB/tests/blob_transaction.txt
+++ b/src/ZODB/tests/blob_transaction.txt
@@ -390,10 +390,6 @@ stored are discarded.
     ...                             '', t)
 
     >>> serials = blob_storage.tpc_vote(t)
-    >>> if s1 is None:
-    ...     s1 = [s for (oid, s) in serials if oid == blob._p_oid][0]
-    >>> if s2 is None:
-    ...     s2 = [s for (oid, s) in serials if oid == new_oid][0]
 
     >>> blob_storage.tpc_abort(t)
 
@@ -402,14 +398,7 @@ Now, the serial for the existing blob should be the same:
     >>> blob_storage.load(blob._p_oid, '') == (olddata, oldserial)
     True
 
-And we shouldn't be able to read the data that we saved:
-
-    >>> blob_storage.loadBlob(blob._p_oid, s1)
-    Traceback (most recent call last):
-    ...
-    POSKeyError: 'No blob file at <BLOB STORAGE PATH>'
-
-Of course the old data should be unaffected:
+The old data should be unaffected:
 
     >>> with open(blob_storage.loadBlob(blob._p_oid, oldserial)) as fp:
     ...     fp.read()


### PR DESCRIPTION
This makes sure that there is support for the new protocol by testing against a storage that supports the new protocol.

Note that ZEO has implemented undo asynchronously and ZODB has supported undone OIDs to be returned via ``tpc_vote`` for for some time. It could be argued whether this is a good thing or a bad thing. (My opinion is that it's simpler to return all affected oids in the vote result, but I don't feel strongly about it.)  It is, however, impractical to change this now.