### PR TITLE
Switch all storages to the new commit protocol

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,13 +10,12 @@ See 4.4.2.
 5.0.0a3 (2016-07-01)
 ====================
 
-Added IMultiCommitStorage to directly represent the changes in the 4.4.0
-release and to make complient storages introspectable.
+See 4.4.1.
 
 5.0.0a2 (2016-07-01)
 ====================
 
-See the 4.4.x releases.
+See 4.4.0.
 
 5.0.0a1 (2016-06-20)
 ====================
@@ -38,7 +37,7 @@ Concurrency Control (MVCC) implementation:
 ==================
 
 Better support of the new commit protocol. This fixes issues with blobs and
-undo. See https://github.com/zopefoundation/ZODB/pull/77
+undo. See pull requests #77, #80, #83
 
 4.4.1 (2016-07-01)
 ==================

--- a/src/ZODB/ConflictResolution.py
+++ b/src/ZODB/ConflictResolution.py
@@ -28,7 +28,7 @@ from pickle import PicklingError
 
 logger = logging.getLogger('ZODB.ConflictResolution')
 
-ResolvedSerial = b'rs' # deprecated: store/tpc_finish should just use True
+ResolvedSerial = b'rs' # deprecated: see IMultiCommitStorage.tpc_vote
 
 class BadClassName(Exception):
     pass

--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -589,7 +589,7 @@ class Connection(ExportImport, object):
 
             self._handle_serial(oid, s)
 
-    def _handle_serial(self, oid, serial=True, change=True):
+    def _handle_serial(self, oid, serial=ResolvedSerial, change=True):
 
         # if we write an object, we don't want to check if it was read
         # while current.  This is a convenient choke point to do this.
@@ -597,10 +597,7 @@ class Connection(ExportImport, object):
 
         if not serial:
             return
-        if serial is True:
-            serial = ResolvedSerial
-        elif not isinstance(serial, bytes):
-            raise serial
+        assert isinstance(serial, bytes), serial
         obj = self._cache.get(oid, None)
         if obj is None:
             return

--- a/src/ZODB/FileStorage/FileStorage.py
+++ b/src/ZODB/FileStorage/FileStorage.py
@@ -520,6 +520,7 @@ class FileStorage(
                 if oldserial != committed_tid:
                     data = self.tryToResolveConflict(oid, committed_tid,
                                                      oldserial, data)
+                    self._resolved.append(oid)
 
             pos = self._pos
             here = pos + self._tfile.tell() + self._thl
@@ -533,9 +534,6 @@ class FileStorage(
             if self._quota is not None and here > self._quota:
                 raise FileStorageQuotaError(
                     "The storage quota has been exceeded.")
-
-            if old and oldserial != committed_tid:
-                self._resolved.append(oid)
 
     def deleteObject(self, oid, oldserial, transaction):
         if self._is_read_only:

--- a/src/ZODB/FileStorage/tests.py
+++ b/src/ZODB/FileStorage/tests.py
@@ -128,10 +128,10 @@ def pack_with_repeated_blob_records():
     >>> fs.tpc_begin(trans)
     >>> with open('ablob', 'w') as file:
     ...     _ = file.write('some data')
-    >>> _ = fs.store(oid, oldserial, blob_record, '', trans)
-    >>> _ = fs.storeBlob(oid, oldserial, blob_record, 'ablob', '', trans)
-    >>> fs.tpc_vote(trans)
-    >>> fs.tpc_finish(trans)
+    >>> fs.store(oid, oldserial, blob_record, '', trans)
+    >>> fs.storeBlob(oid, oldserial, blob_record, 'ablob', '', trans)
+    >>> _ = fs.tpc_vote(trans)
+    >>> _ = fs.tpc_finish(trans)
 
     >>> time.sleep(.01)
     >>> db.pack()
@@ -156,9 +156,9 @@ _save_index can fail for large indexes.
     >>> oid = 0
     >>> for i in range(5000):
     ...     oid += (1<<16)
-    ...     _ = fs.store(ZODB.utils.p64(oid), ZODB.utils.z64, b'x', '', t)
-    >>> fs.tpc_vote(t)
-    >>> fs.tpc_finish(t)
+    ...     fs.store(ZODB.utils.p64(oid), ZODB.utils.z64, b'x', '', t)
+    >>> _ = fs.tpc_vote(t)
+    >>> _ = fs.tpc_finish(t)
 
     >>> import sys
     >>> old_limit = sys.getrecursionlimit()

--- a/src/ZODB/MappingStorage.py
+++ b/src/ZODB/MappingStorage.py
@@ -43,7 +43,6 @@ class MappingStorage(object):
         self._commit_lock = ZODB.utils.Lock()
         self._opened = True
         self._transaction = None
-        self._resolved = []
         self._oid = 0
 
     ######################################################################
@@ -233,7 +232,7 @@ class MappingStorage(object):
 
     # ZODB.interfaces.IStorage
     @ZODB.utils.locked(opened)
-    def store(self, oid, serial, data, version, transaction, resolved=False):
+    def store(self, oid, serial, data, version, transaction):
         assert not version, "Versions are not supported"
         if transaction is not self._transaction:
             raise ZODB.POSException.StorageTransactionError(self, transaction)
@@ -247,8 +246,6 @@ class MappingStorage(object):
                     oid=oid, serials=(old_tid, serial), data=data)
 
         self._tdata[oid] = data
-        if resolved:
-            self._resolved.append(oid)
 
     checkCurrentSerialInTransaction = (
         ZODB.BaseStorage.checkCurrentSerialInTransaction)
@@ -284,7 +281,6 @@ class MappingStorage(object):
                     old_tid = None
                 tid = ZODB.utils.newTid(old_tid)
             self._tid = tid
-            del self._resolved[:]
 
     # ZODB.interfaces.IStorage
     @ZODB.utils.locked(opened)
@@ -321,7 +317,6 @@ class MappingStorage(object):
         if transaction is not self._transaction:
             raise ZODB.POSException.StorageTransactionError(
                 "tpc_vote called with wrong transaction")
-        return self._resolved
 
 class TransactionRecord:
 

--- a/src/ZODB/tests/IExternalGC.test
+++ b/src/ZODB/tests/IExternalGC.test
@@ -45,9 +45,10 @@ transaction ourselves.
     >>> storage.tpc_begin(txn)
     >>> storage.deleteObject(oid0, s0, txn)
     >>> storage.deleteObject(oid1, s1, txn)
-    >>> storage.tpc_vote(txn)
-    >>> storage.tpc_finish(txn)
-    >>> tid = storage.lastTransaction()
+    >>> _ = storage.tpc_vote(txn)
+    >>> tid = storage.tpc_finish(txn)
+    >>> tid == storage.lastTransaction()
+    True
 
 Now if we try to load data for the objects, we get a POSKeyError:
 

--- a/src/ZODB/tests/StorageTestBase.py
+++ b/src/ZODB/tests/StorageTestBase.py
@@ -118,9 +118,7 @@ def handle_all_serials(oid, *args):
     for arg in args:
         if isinstance(arg, bytes):
             d[oid] = arg
-        elif arg is None:
-            pass
-        else:
+        elif arg:
             for oid, serial in arg:
                 if not isinstance(serial, bytes):
                     raise serial # error from ZEO server

--- a/src/ZODB/tests/blob_transaction.txt
+++ b/src/ZODB/tests/blob_transaction.txt
@@ -381,16 +381,17 @@ stored are discarded.
     >>> blob_storage.tpc_begin(t)
     >>> with open('blobfile', 'wb') as file:
     ...     _ = file.write(b'This data should go away')
-    >>> s1 = blob_storage.storeBlob(blob._p_oid, oldserial, olddata, 'blobfile',
+    >>> blob_storage.storeBlob(blob._p_oid, oldserial, olddata, 'blobfile',
     ...                             '', t)
     >>> new_oid = blob_storage.new_oid()
     >>> with open('blobfile2', 'wb') as file:
     ...     _ = file.write(b'This data should go away too')
-    >>> s2 = blob_storage.storeBlob(new_oid, '\0'*8, olddata, 'blobfile2',
+    >>> blob_storage.storeBlob(new_oid, '\0'*8, olddata, 'blobfile2',
     ...                             '', t)
-
-    >>> serials = blob_storage.tpc_vote(t)
-
+    >>> bool(blob_storage.tpc_vote(t))
+    False
+    >>> oldserial < blob_storage._tid
+    True
     >>> blob_storage.tpc_abort(t)
 
 Now, the serial for the existing blob should be the same:

--- a/src/ZODB/tests/blob_transaction.txt
+++ b/src/ZODB/tests/blob_transaction.txt
@@ -390,8 +390,6 @@ stored are discarded.
     ...                             '', t)
     >>> bool(blob_storage.tpc_vote(t))
     False
-    >>> oldserial < blob_storage._tid
-    True
     >>> blob_storage.tpc_abort(t)
 
 Now, the serial for the existing blob should be the same:

--- a/src/ZODB/tests/testDemoStorage.py
+++ b/src/ZODB/tests/testDemoStorage.py
@@ -49,8 +49,6 @@ from ZODB.ConflictResolution import ResolvedSerial
 
 class DemoStorage(ZODB.DemoStorage.DemoStorage):
 
-    delayed_store = False
-
     def tpc_begin(self, *args):
         super(DemoStorage, self).tpc_begin(*args)
         self.__stored = []
@@ -60,8 +58,6 @@ class DemoStorage(ZODB.DemoStorage.DemoStorage):
         if s != ResolvedSerial:
             assert type(s) is bytes, s
             return
-        if not self.delayed_store:
-            return True
         self.__stored.append(oid)
 
     tpc_vote = property(lambda self: self._tpc_vote, lambda *_: None)
@@ -69,7 +65,7 @@ class DemoStorage(ZODB.DemoStorage.DemoStorage):
     def _tpc_vote(self, transaction):
         s = self.changes.tpc_vote(transaction)
         assert s is None, s
-        return self.__stored if self.delayed_store else s
+        return self.__stored
 
     def tpc_finish(self, transaction, func = lambda tid: None):
         r = []
@@ -145,11 +141,6 @@ class DemoStorageTests(
             yield 14
         self._checkHistory(base_and_changes())
         self._storage = self._storage.pop()
-
-    def checkResolveLate(self):
-        self._storage.delayed_store = True
-        self.checkResolve()
-
 
 class DemoStorageHexTests(DemoStorageTests):
 


### PR DESCRIPTION
This does not clean up tests. In particular, the test using MultiCommitAdapter becomes useless (and IMO, MultiCommitAdapter too). Several changes from 74fba08ad4dc7311ca74c5c9da51c12e0e9dca86 could be also simplified.