### PR TITLE
Only tpc_vote can report resolved conflicts with the new commit protocol

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@
 ==================
 
 Better support of the new commit protocol. This fixes issues with blobs and
-undo. See https://github.com/zopefoundation/ZODB/pull/77
+undo. See pull requests #77, #80, #83
 
 4.4.1 (2016-07-01)
 ==================

--- a/src/ZODB/ConflictResolution.py
+++ b/src/ZODB/ConflictResolution.py
@@ -28,7 +28,7 @@ from pickle import PicklingError
 
 logger = logging.getLogger('ZODB.ConflictResolution')
 
-ResolvedSerial = b'rs' # deprecated: store/tpc_finish should just use True
+ResolvedSerial = b'rs' # deprecated: see IMultiCommitStorage.tpc_vote
 
 class BadClassName(Exception):
     pass

--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -706,7 +706,7 @@ class Connection(ExportImport, object):
 
             self._handle_serial(oid, s)
 
-    def _handle_serial(self, oid, serial=True, change=True):
+    def _handle_serial(self, oid, serial=ResolvedSerial, change=True):
 
         # if we write an object, we don't want to check if it was read
         # while current.  This is a convenient choke point to do this.
@@ -714,10 +714,7 @@ class Connection(ExportImport, object):
 
         if not serial:
             return
-        if serial is True:
-            serial = ResolvedSerial
-        elif not isinstance(serial, bytes):
-            raise serial
+        assert isinstance(serial, bytes), serial
         obj = self._cache.get(oid, None)
         if obj is None:
             return

--- a/src/ZODB/tests/testDemoStorage.py
+++ b/src/ZODB/tests/testDemoStorage.py
@@ -46,8 +46,6 @@ from ZODB.ConflictResolution import ResolvedSerial
 
 class DemoStorage(ZODB.DemoStorage.DemoStorage):
 
-    delayed_store = False
-
     def tpc_begin(self, *args):
         super(DemoStorage, self).tpc_begin(*args)
         self.__stored = []
@@ -57,8 +55,6 @@ class DemoStorage(ZODB.DemoStorage.DemoStorage):
         if s != ResolvedSerial:
             assert type(s) is bytes, s
             return
-        if not self.delayed_store:
-            return True
         self.__stored.append(oid)
 
     tpc_vote = property(lambda self: self._tpc_vote, lambda *_: None)
@@ -66,7 +62,7 @@ class DemoStorage(ZODB.DemoStorage.DemoStorage):
     def _tpc_vote(self, transaction):
         s = self.changes.tpc_vote(transaction)
         assert s is None, s
-        return self.__stored if self.delayed_store else s
+        return self.__stored
 
     def tpc_finish(self, transaction, func = lambda tid: None):
         r = []
@@ -142,11 +138,6 @@ class DemoStorageTests(
             yield 14
         self._checkHistory(base_and_changes())
         self._storage = self._storage.pop()
-
-    def checkResolveLate(self):
-        self._storage.delayed_store = True
-        self.checkResolve()
-
 
 class DemoStorageHexTests(DemoStorageTests):
 


### PR DESCRIPTION
To follow the interface.
That's the easy part, for the 4.x branch.