### PR TITLE
Fix handle_all_serials for the new and old protocols.

### DIFF
--- a/src/ZODB/tests/StorageTestBase.py
+++ b/src/ZODB/tests/StorageTestBase.py
@@ -113,16 +113,24 @@ def handle_all_serials(oid, *args):
 
     The original interface just returned the serialno for the
     object.
+
+    The updated multi-commit API returns nothing from store(), and
+    returns a sequence of resolved oids from tpc_vote.
     """
     d = {}
     for arg in args:
         if isinstance(arg, bytes):
             d[oid] = arg
         elif arg:
-            for oid, serial in arg:
-                if not isinstance(serial, bytes):
-                    raise serial # error from ZEO server
-                d[oid] = serial
+            for t in arg:
+                if isinstance(t, bytes):
+                    # This will be the tid returned by tpc_finish.
+                    pass
+                else:
+                    oid, serial = t
+                    if not isinstance(serial, bytes):
+                        raise serial # error from ZEO server
+                    d[oid] = serial
     return d
 
 def handle_serials(oid, *args):


### PR DESCRIPTION
Fixes a bunch of test failures in RelStorage.

_dostore calls this with the results of `storage.store` (`None`) and `storage.tpc_vote` (set of oids---usually empty unless there's a resolved conflict, in which case you get a TypeError unpacking)

A similar thing will need to be done for the branch that is ZODB4, possibly just cherry-pick this commit?