### PR TITLE
Per @jimfulton, handle_all_serials shouldn't be sniffing in ZODB5

### DIFF
--- a/src/ZODB/tests/BasicStorage.py
+++ b/src/ZODB/tests/BasicStorage.py
@@ -21,7 +21,6 @@ All storages should be able to pass these tests.
 from ZODB import POSException
 from ZODB.tests.MinPO import MinPO
 from ZODB.tests.StorageTestBase import zodb_unpickle, zodb_pickle
-from ZODB.tests.StorageTestBase import handle_serials
 
 import threading
 import time
@@ -68,13 +67,10 @@ class BasicStorage:
         self._storage.tpc_begin(txn)
         # Use None for serial.  Don't use _dostore() here because that coerces
         # serial=None to serial=ZERO.
-        r1 = self._storage.store(oid, None, zodb_pickle(MinPO(11)),
-                                       '', txn)
-        r2 = self._storage.tpc_vote(txn)
-        serial = self._storage.tpc_finish(txn)
-        newrevid = handle_serials(oid, r1, r2)
-        if newrevid is None and serial is not None:
-            newrevid = serial
+        self._storage.store(oid, None, zodb_pickle(MinPO(11)),
+                            '', txn)
+        self._storage.tpc_vote(txn)
+        newrevid = self._storage.tpc_finish(txn)
         data, revid = utils.load_current(self._storage, oid)
         value = zodb_unpickle(data)
         eq(value, MinPO(11))

--- a/src/ZODB/tests/MTStorage.py
+++ b/src/ZODB/tests/MTStorage.py
@@ -9,7 +9,6 @@ import transaction
 
 import ZODB
 from ZODB.tests.StorageTestBase import zodb_pickle, zodb_unpickle
-from ZODB.tests.StorageTestBase import handle_serials
 from ZODB.tests.MinPO import MinPO
 from ZODB.POSException import ConflictError
 
@@ -149,18 +148,14 @@ class StorageClientThread(TestThread):
         self.pause()
 
         # Always create a new object, signified by None for revid
-        r1 = self.storage.store(oid, None, data, '', t)
+        self.storage.store(oid, None, data, '', t)
         self.pause()
 
-        r2 = self.storage.tpc_vote(t)
+        self.storage.tpc_vote(t)
         self.pause()
 
-        serial = self.storage.tpc_finish(t)
+        revid = self.storage.tpc_finish(t)
         self.pause()
-
-        revid = handle_serials(oid, r1, r2)
-        if serial is not None and revid is None:
-            revid = serial
         self.oids[oid] = revid
 
 class ExtStorageClientThread(StorageClientThread):

--- a/src/ZODB/tests/RevisionStorage.py
+++ b/src/ZODB/tests/RevisionStorage.py
@@ -15,7 +15,6 @@
 
 from ZODB.tests.MinPO import MinPO
 from ZODB.tests.StorageTestBase import zodb_unpickle, zodb_pickle, snooze
-from ZODB.tests.StorageTestBase import handle_serials
 from ZODB.utils import p64, u64, load_current
 
 import transaction
@@ -146,16 +145,13 @@ class RevisionStorage:
             t = transaction.Transaction()
             try:
                 self._storage.tpc_begin(t, p64(tid))
-                r1 = self._storage.store(oid, revid, data, '', t)
+                self._storage.store(oid, revid, data, '', t)
                 # Finish the transaction
-                r2 = self._storage.tpc_vote(t)
-                newrevid = handle_serials(oid, r1, r2)
-                serial = self._storage.tpc_finish(t)
+                self._storage.tpc_vote(t)
+                newrevid = self._storage.tpc_finish(t)
             except:
                 self._storage.tpc_abort(t)
                 raise
-            if serial is not None and newrevid is None:
-                newrevid = serial
             return newrevid
         revid1 = helper(1, None, 1)
         revid2 = helper(2, revid1, 2)

--- a/src/ZODB/tests/StorageTestBase.py
+++ b/src/ZODB/tests/StorageTestBase.py
@@ -111,11 +111,8 @@ def handle_all_serials(oid, *args):
     This is pointless with IMultiCommitStorage.
     """
     d = {}
-    for arg in args:
-        if arg: # store() will have passed us None
-            for t in arg:
-                assert isinstance(t, bytes)
-                # This will be the tid returned by tpc_finish.
+    # On empty dict, _dostore will choose the serial returned from
+    # tpc_finish.
     return d
 
 def handle_serials(oid, *args):

--- a/src/ZODB/tests/StorageTestBase.py
+++ b/src/ZODB/tests/StorageTestBase.py
@@ -101,29 +101,6 @@ def zodb_unpickle(data):
     inst.__setstate__(state)
     return inst
 
-def handle_all_serials(oid, *args):
-    """
-    Return dict of oid to serialno from store() and tpc_vote().
-
-    The updated multi-commit API returns nothing from store(), and
-    returns a sequence of resolved oids from tpc_vote.
-
-    This is pointless with IMultiCommitStorage.
-    """
-    d = {}
-    # On empty dict, _dostore will choose the serial returned from
-    # tpc_finish.
-    return d
-
-def handle_serials(oid, *args):
-    """Return the serialno for oid based on multiple return values.
-
-    A helper for function _handle_all_serials().
-
-    This is pointless with IMultiCommitStorage.
-    """
-    return handle_all_serials(oid, *args).get(oid)
-
 def import_helper(name):
     __import__(name)
     return sys.modules[name]

--- a/src/ZODB/tests/StorageTestBase.py
+++ b/src/ZODB/tests/StorageTestBase.py
@@ -102,41 +102,28 @@ def zodb_unpickle(data):
     return inst
 
 def handle_all_serials(oid, *args):
-    """Return dict of oid to serialno from store() and tpc_vote().
-
-    Raises an exception if one of the calls raised an exception.
-
-    The storage interface got complicated when ZEO was introduced.
-    Any individual store() call can return None or a sequence of
-    2-tuples where the 2-tuple is either oid, serialno or an
-    exception to be raised by the client.
-
-    The original interface just returned the serialno for the
-    object.
+    """
+    Return dict of oid to serialno from store() and tpc_vote().
 
     The updated multi-commit API returns nothing from store(), and
     returns a sequence of resolved oids from tpc_vote.
+
+    This is pointless with IMultiCommitStorage.
     """
     d = {}
     for arg in args:
-        if isinstance(arg, bytes):
-            d[oid] = arg
-        elif arg:
+        if arg: # store() will have passed us None
             for t in arg:
-                if isinstance(t, bytes):
-                    # This will be the tid returned by tpc_finish.
-                    pass
-                else:
-                    oid, serial = t
-                    if not isinstance(serial, bytes):
-                        raise serial # error from ZEO server
-                    d[oid] = serial
+                assert isinstance(t, bytes)
+                # This will be the tid returned by tpc_finish.
     return d
 
 def handle_serials(oid, *args):
     """Return the serialno for oid based on multiple return values.
 
     A helper for function _handle_all_serials().
+
+    This is pointless with IMultiCommitStorage.
     """
     return handle_all_serials(oid, *args).get(oid)
 
@@ -194,10 +181,7 @@ class StorageTestBase(ZODB.tests.util.TestCase):
             r1 = self._storage.store(oid, revid, data, '', t)
             # Finish the transaction
             r2 = self._storage.tpc_vote(t)
-            revid = handle_serials(oid, r1, r2)
-            serial = self._storage.tpc_finish(t)
-            if serial is not None and revid is None:
-                revid = serial
+            revid = self._storage.tpc_finish(t)
         except:
             self._storage.tpc_abort(t)
             raise


### PR DESCRIPTION
So try that. This slightly simplifies _dostore.

There are lots of other callers still so I didn't remove the functions entirely (but I could try if desired).