### PR TITLE
fstail: print the txn offset and header size, instead of only the data offset

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@
 - Internal FileStorage-undo fixes that should allow undo in some cases
   where it didn't work before.
 
+- fstail: print the txn offset and header size, instead of only the data offset.
+  fstail can now be used to truncate a DB at the right offset.
+
 4.4.2 (2016-07-08)
 ==================
 

--- a/src/ZODB/fstools.py
+++ b/src/ZODB/fstools.py
@@ -67,9 +67,14 @@ class TxnHeader:
             self._ext = self._file.read(self.ext_len)
             self.ext = loads(self._ext)
 
+    def get_offset(self):
+        return self._pos
+
+    def __len__(self):
+        return TRANS_HDR_LEN + self.user_len + self.descr_len + self.ext_len
+
     def get_data_offset(self):
-        return (self._pos + TRANS_HDR_LEN + self.user_len + self.descr_len
-                + self.ext_len)
+        return self._pos + len(self)
 
     def get_timestamp(self):
         return TimeStamp(self.tid)

--- a/src/ZODB/scripts/fstail.py
+++ b/src/ZODB/scripts/fstail.py
@@ -36,8 +36,8 @@ def main(path, ntxn):
             th.read_meta()
             print("%s: hash=%s" % (th.get_timestamp(),
                                    binascii.hexlify(hash).decode()))
-            print(("user=%r description=%r length=%d offset=%d"
-                   % (th.user, th.descr, th.length, th.get_data_offset())))
+            print(("user=%r description=%r length=%d offset=%d (+%d)"
+                   % (th.user, th.descr, th.length, th.get_offset(), len(th))))
             print()
             th = th.prev_txn()
             i -= 1

--- a/src/ZODB/scripts/tests/fstail.txt
+++ b/src/ZODB/scripts/tests/fstail.txt
@@ -24,10 +24,10 @@ Now lets have a look at the last transactions of this FileStorage:
   >>> from ZODB.scripts.fstail import main
   >>> main(storagefile, 5)
   2007-11-10 15:18:48.543001: hash=b16422d09fabdb45d4e4325e4b42d7d6f021d3c3
-  user='' description='' length=132 offset=185
+  user='' description='' length=132 offset=162 (+23)
   <BLANKLINE>
   2007-11-10 15:18:48.543001: hash=b16422d09fabdb45d4e4325e4b42d7d6f021d3c3
-  user='' description='initial database creation' length=150 offset=52
+  user='' description='initial database creation' length=150 offset=4 (+48)
   <BLANKLINE>
 
 Now clean up the storage again:

--- a/src/ZODB/scripts/tests/test_doc.py
+++ b/src/ZODB/scripts/tests/test_doc.py
@@ -29,13 +29,13 @@ checker = zope.testing.renormalizing.RENormalizing([
     # Python 3 produces larger pickles, even when we use zodbpickle :(
     # this changes all the offsets and sizes in fstail.txt
     (re.compile("user='' description='' "
-                    "length=[0-9]+ offset=[0-9]+"),
+                    "length=[0-9]+ offset=[0-9]+ \(\+23\)"),
                 "user='' description='' "
-                    "length=<LENGTH> offset=<OFFSET>"),
+                    "length=<LENGTH> offset=<OFFSET> (+23)"),
     (re.compile("user='' description='initial database creation' "
-                    "length=[0-9]+ offset=[0-9]+"),
+                    "length=[0-9]+ offset=4 \(\+48\)"),
                 "user='' description='initial database creation' "
-                    "length=<<LENGTH> offset=<OFFSET>"),
+                    "length=<LENGTH> offset=4 (+48)"),
 ])
 
 def test_suite():


### PR DESCRIPTION
Before:

    2016-07-01 09:41:50.416574: hash=d7101c5ee7b8e412d7b6d54873204421e09b7f34
    user='' description='' length=1629 offset=58990284

After:

    2016-07-01 09:41:50.416574: hash=d7101c5ee7b8e412d7b6d54873204421e09b7f34
    user='' description='' length=1629 offset=58990261 (+23)

The structure of a FileStorage DB is such that it's easy to revert the last
transactions, by truncating the file at the right offset. With the above
change, `fstail` can now be used to get this offset.

In the above example:

    truncate -s 58990261 Data.fs

would delete the transaction and all those after.