### PR TITLE
Refactored FileStorage transactional undo

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
  Change History
 ================
 
+4.4.3 (unreleased)
+==================
+
+- Internal FileStorage-undo fixes that should allow undo in some cases
+  where it didn't work before.
+
 4.4.2 (2016-07-08)
 ==================
 

--- a/src/ZODB/ConflictResolution.py
+++ b/src/ZODB/ConflictResolution.py
@@ -18,7 +18,8 @@ import six
 import zope.interface
 from ZODB.POSException import ConflictError
 from ZODB.loglevels import BLATHER
-from ZODB._compat import BytesIO, PersistentUnpickler, PersistentPickler, _protocol
+from ZODB._compat import (
+    BytesIO, PersistentUnpickler, PersistentPickler, _protocol)
 
 # Subtle: Python 2.x has pickle.PicklingError and cPickle.PicklingError,
 # and these are unrelated classes!  So we shouldn't use pickle.PicklingError,
@@ -73,7 +74,8 @@ def state(self, oid, serial, prfactory, p=''):
     p = p or self.loadSerial(oid, serial)
     p = self._crs_untransform_record_data(p)
     file = BytesIO(p)
-    unpickler = PersistentUnpickler(find_global, prfactory.persistent_load, file)
+    unpickler = PersistentUnpickler(
+        find_global, prfactory.persistent_load, file)
     unpickler.load() # skip the class tuple
     return unpickler.load()
 
@@ -241,7 +243,8 @@ def tryToResolveConflict(self, oid, committedSerial, oldSerial, newpickle,
         prfactory = PersistentReferenceFactory()
         newpickle = self._crs_untransform_record_data(newpickle)
         file = BytesIO(newpickle)
-        unpickler = PersistentUnpickler(find_global, prfactory.persistent_load, file)
+        unpickler = PersistentUnpickler(
+            find_global, prfactory.persistent_load, file)
         meta = unpickler.load()
         if isinstance(meta, tuple):
             klass = meta[0]

--- a/src/ZODB/FileStorage/FileStorage.py
+++ b/src/ZODB/FileStorage/FileStorage.py
@@ -865,11 +865,6 @@ class FileStorage(
 
                 try:
                     data_to_be_undone = self._loadBack_impl(oid, pos)[0]
-
-                    # Note that we use ``cdata or`` below, because
-                    # _loadBackPOS dosn't work with in-tranaaction
-                    # data and because we don't need to bother if we
-                    # already have the data.
                     if not current_data:
                         current_data = self._loadBack_impl(oid, cdataptr)[0]
 


### PR DESCRIPTION
As part of a project to provide object-level commit locks for ZEO, I'm
refactiring FileStorage to maintain transaction-specific data in
Tranaction.data.  This involved undo.  In trying to figure this out, I
found:

- A bug in _undoDataInfo, which I verified with some tests and

- _transactionalUndoRecord was maddeningly difficult to reason about
  (and thus change).

I was concerned less by the bug than my inability to know whether a
change to the code would be correct.

So I refactored the code, mainly transactionalUndoRecord, to make the
code easier to understand, fixing some logic errors (I'm pretty sure)
along the way.  This included lots of comments. (Comments are much
easier to compose when you're working out logic you didn't
understand.)

In addition to makeing the code cleaner, it allows undo to be handled
in cases that weren't handled before.