### PR TITLE
Fix testMinimizeTerminates

### DIFF
--- a/src/ZODB/tests/testCache.py
+++ b/src/ZODB/tests/testCache.py
@@ -142,6 +142,13 @@ class DBMethods(CacheTestBase):
         # isn't looking out for this, it can get into an infinite loop
         # then, endlessly trying to ghostify an object that in turn keeps
         # unghostifying itself again.
+
+        # This test uses threads, so we can't use the default
+        # transaction manager.
+        for conn in self.conns:
+            conn.close()
+        self.conns[0] = self.db.open(transaction.TransactionManager())
+
         class Worker(threading.Thread):
 
             def __init__(self, testcase):
@@ -158,7 +165,7 @@ class DBMethods(CacheTestBase):
                 d = r[1]
                 for i in range(len(d)):
                     d[i] = CantGetRidOfMe(i)
-                transaction.commit()
+                conn.transaction_manager.commit()
 
                 self.testcase.db.cacheMinimize()
 


### PR DESCRIPTION
This test was spewing exceptions without failing for ZODB5.

The spew was an indication that something was wrong in this case. (The
test was broken.)

There had been some bug in the object cache that caused an infinite
loop when objects woke themselves up while being reaped.  This test is
a regression test for that bug.

The test was sloppy about transaction managers.  The test class
creates a bunch of connections using the threaded transaction manager,
but this test used a thread to execute the critical code.  As a
result, the synchronization methods weren't called.  This didn't
matter much with ZODB4.  The objects were still able to load their
state.

With ZODB5, the synchronization methods are important for proper MVCC
and because they weren't called, the objects' state couldn't be
reloaded, with 2 effects:

- Spew

- The test wasn't really testing that object's that reloaded
  themselves didn't create an infinite loop.

Changed the test to not use a threaded transaction manager.