### PR TITLE
Changed DB root-object-initialization to use an open connection and more

### DIFF
--- a/src/ZODB/FileStorage/iterator.test
+++ b/src/ZODB/FileStorage/iterator.test
@@ -6,18 +6,6 @@ special tests.
 
 We'll make some assertions about time, so we'll take it over:
 
-    >>> now = 1229959248
-    >>> def faux_time():
-    ...     global now
-    ...     now += 0.1
-    ...     return now
-    >>> import time
-    >>> time_time = time.time
-    >>> if isinstance(time,type):
-    ...    time.time = staticmethod(faux_time) # Jython
-    ... else:
-    ...     time.time = faux_time
-
 Commit a bunch of transactions:
 
     >>> import ZODB.FileStorage, transaction
@@ -63,28 +51,32 @@ seems best and set the next record to that:
     >>> it.close()
 
     >>> it = ZODB.FileStorage.FileIterator('data.fs', tids[1])
-    Scan forward data.fs:<OFFSET> looking for '\x03z\xbd\xd8\xd06\x9c\xcc'
+    ... # doctest: +ELLIPSIS
+    Scan forward data.fs:<OFFSET> looking for '...'
     >>> it.next().tid == tids[1]
     True
 
     >>> it.close()
 
     >>> it = ZODB.FileStorage.FileIterator('data.fs', tids[30])
-    Scan forward data.fs:<OFFSET> looking for '\x03z\xbd\xd8\xdc\x96.\xcc'
+    ... # doctest: +ELLIPSIS
+    Scan forward data.fs:<OFFSET> looking for '...'
     >>> it.next().tid == tids[30]
     True
 
     >>> it.close()
 
     >>> it = ZODB.FileStorage.FileIterator('data.fs', tids[70])
-    Scan backward data.fs:<OFFSET> looking for '\x03z\xbd\xd8\xed\xa7>\xcc'
+    ... # doctest: +ELLIPSIS
+    Scan backward data.fs:<OFFSET> looking for '...'
     >>> it.next().tid == tids[70]
     True
 
     >>> it.close()
 
     >>> it = ZODB.FileStorage.FileIterator('data.fs', tids[-2])
-    Scan backward data.fs:<OFFSET> looking for '\x03z\xbd\xd8\xfa\x06\xd0\xcc'
+    ... # doctest: +ELLIPSIS
+    Scan backward data.fs:<OFFSET> looking for '...'
     >>> it.next().tid == tids[-2]
     True
 
@@ -118,14 +110,16 @@ starting point, or just pick up where another iterator left off:
     >>> it.close()
 
     >>> it = ZODB.FileStorage.FileIterator('data.fs', tids[50], pos=poss[50])
-    Scan backward data.fs:<OFFSET> looking for '\x03z\xbd\xd8\xe5\x1e\xb6\xcc'
+    ... # doctest: +ELLIPSIS
+    Scan backward data.fs:<OFFSET> looking for '...'
     >>> it.next().tid == tids[50]
     True
 
     >>> it.close()
 
     >>> it = ZODB.FileStorage.FileIterator('data.fs', tids[49], pos=poss[50])
-    Scan backward data.fs:<OFFSET> looking for '\x03z\xbd\xd8\xe4\xb1|\xcc'
+    ... # doctest: +ELLIPSIS
+    Scan backward data.fs:<OFFSET> looking for '...'
     >>> it.next().tid == tids[49]
     True
 
@@ -172,5 +166,4 @@ Even if we write more transactions:
 
 .. Cleanup
 
-    >>> time.time = time_time
     >>> db.close()

--- a/src/ZODB/FileStorage/iterator.test
+++ b/src/ZODB/FileStorage/iterator.test
@@ -6,6 +6,18 @@ special tests.
 
 We'll make some assertions about time, so we'll take it over:
 
+    >>> now = 1229959248
+    >>> def faux_time():
+    ...     global now
+    ...     now += 0.1
+    ...     return now
+    >>> import time
+    >>> time_time = time.time
+    >>> if isinstance(time,type):
+    ...    time.time = staticmethod(faux_time) # Jython
+    ... else:
+    ...     time.time = faux_time
+
 Commit a bunch of transactions:
 
     >>> import ZODB.FileStorage, transaction
@@ -166,4 +178,5 @@ Even if we write more transactions:
 
 .. Cleanup
 
+    >>> time.time = time_time
     >>> db.close()

--- a/src/ZODB/FileStorage/iterator.test
+++ b/src/ZODB/FileStorage/iterator.test
@@ -52,7 +52,7 @@ seems best and set the next record to that:
 
     >>> it = ZODB.FileStorage.FileIterator('data.fs', tids[1])
     ... # doctest: +ELLIPSIS
-    Scan forward data.fs:<OFFSET> looking for '...'
+    Scan forward data.fs:<OFFSET> looking for ...
     >>> it.next().tid == tids[1]
     True
 
@@ -60,7 +60,7 @@ seems best and set the next record to that:
 
     >>> it = ZODB.FileStorage.FileIterator('data.fs', tids[30])
     ... # doctest: +ELLIPSIS
-    Scan forward data.fs:<OFFSET> looking for '...'
+    Scan forward data.fs:<OFFSET> looking for ...
     >>> it.next().tid == tids[30]
     True
 
@@ -68,7 +68,7 @@ seems best and set the next record to that:
 
     >>> it = ZODB.FileStorage.FileIterator('data.fs', tids[70])
     ... # doctest: +ELLIPSIS
-    Scan backward data.fs:<OFFSET> looking for '...'
+    Scan backward data.fs:<OFFSET> looking for ...
     >>> it.next().tid == tids[70]
     True
 
@@ -76,7 +76,7 @@ seems best and set the next record to that:
 
     >>> it = ZODB.FileStorage.FileIterator('data.fs', tids[-2])
     ... # doctest: +ELLIPSIS
-    Scan backward data.fs:<OFFSET> looking for '...'
+    Scan backward data.fs:<OFFSET> looking for ...
     >>> it.next().tid == tids[-2]
     True
 
@@ -111,7 +111,7 @@ starting point, or just pick up where another iterator left off:
 
     >>> it = ZODB.FileStorage.FileIterator('data.fs', tids[50], pos=poss[50])
     ... # doctest: +ELLIPSIS
-    Scan backward data.fs:<OFFSET> looking for '...'
+    Scan backward data.fs:<OFFSET> looking for ...
     >>> it.next().tid == tids[50]
     True
 
@@ -119,7 +119,7 @@ starting point, or just pick up where another iterator left off:
 
     >>> it = ZODB.FileStorage.FileIterator('data.fs', tids[49], pos=poss[50])
     ... # doctest: +ELLIPSIS
-    Scan backward data.fs:<OFFSET> looking for '...'
+    Scan backward data.fs:<OFFSET> looking for ...
     >>> it.next().tid == tids[49]
     True
 

--- a/src/ZODB/tests/dbopen.txt
+++ b/src/ZODB/tests/dbopen.txt
@@ -126,6 +126,7 @@ returned are distinct:
     >>> st = Storage()
     >>> db = DB(st)
     >>> c1 = db.open()
+    >>> c1.cacheMinimize()
     >>> c2 = db.open()
     >>> c3 = db.open()
     >>> c1 is c2 or c1 is c3 or c2 is c3
@@ -260,6 +261,7 @@ closed one out of the available connection stack.
     >>> st = Storage()
     >>> db = DB(st, pool_size=3)
     >>> conns = [db.open() for dummy in range(6)]
+    >>> conns[0].cacheMinimize()
     >>> len(handler.records)  # 3 warnings for the "excess" connections
     3
     >>> pool = db.pool
@@ -328,6 +330,7 @@ resources (like RDB connections), for the duration.
     >>> st = Storage()
     >>> db = DB(st, pool_size=2)
     >>> conn0 = db.open()
+    >>> conn0.cacheMinimize() # See fix84.rst
     >>> len(conn0._cache)  # empty now
     0
     >>> import transaction

--- a/src/ZODB/tests/dbopen.txt
+++ b/src/ZODB/tests/dbopen.txt
@@ -330,7 +330,7 @@ resources (like RDB connections), for the duration.
     >>> st = Storage()
     >>> db = DB(st, pool_size=2)
     >>> conn0 = db.open()
-    >>> conn0.cacheMinimize() # See fix84.rst
+    >>> conn0.cacheMinimize(); import gc; _ = gc.collect() # See fix84.rst
     >>> len(conn0._cache)  # empty now
     0
     >>> import transaction

--- a/src/ZODB/tests/fix84.rst
+++ b/src/ZODB/tests/fix84.rst
@@ -1,0 +1,19 @@
+A change in the way databases were initialized affected tests
+=============================================================
+
+Originally, databases added root objects by interacting directly with
+storages, rather than using connections.  As storages transaction
+interaction became more complex, interacting directly with storages
+let to duplicated code (and buggy) code.
+
+See: https://github.com/zopefoundation/ZODB/issues/84
+
+Fixing this had some impacts that affected tests:
+
+- New databases now have a connection with a single object in it's cache.
+  This is a very slightly good thing, but it broke some tests expectations.
+
+- Tests that manipulated time, had their clocks off because of new time calls.
+
+This led to some test fixes, in many cases adding a mysterious
+``cacheMinimize()`` call.

--- a/src/ZODB/tests/synchronizers.txt
+++ b/src/ZODB/tests/synchronizers.txt
@@ -21,6 +21,7 @@ Make a change locally:
 
     >>> st = SimpleStorage()
     >>> db = ZODB.DB(st)
+    >>> st.sync_called = False
     >>> cn = db.open()
     >>> rt = cn.root()
     >>> rt['a'] = 1

--- a/src/ZODB/tests/testCache.py
+++ b/src/ZODB/tests/testCache.py
@@ -444,7 +444,7 @@ def test_basic_cache_size_estimation():
     >>> import ZODB.MappingStorage
     >>> db = ZODB.MappingStorage.DB()
     >>> conn = db.open()
-    >>> conn.cacheMinimize() # See fix84.rst
+    >>> conn.cacheMinimize(); _ = gc.collect() # See fix84.rst
 
     >>> def check_cache_size(cache, expected):
     ...     actual = cache.total_estimated_size

--- a/src/ZODB/tests/testCache.py
+++ b/src/ZODB/tests/testCache.py
@@ -237,8 +237,8 @@ class LRUCacheTests(CacheTestBase):
             # not bother to check this
 
     def testSize(self):
+        self.db.cacheMinimize()
         self.assertEqual(self.db.cacheSize(), 0)
-        self.assertEqual(self.db.cacheDetailSize(), [])
 
         CACHE_SIZE = 10
         self.db.setCacheSize(CACHE_SIZE)
@@ -444,6 +444,7 @@ def test_basic_cache_size_estimation():
     >>> import ZODB.MappingStorage
     >>> db = ZODB.MappingStorage.DB()
     >>> conn = db.open()
+    >>> conn.cacheMinimize() # See fix84.rst
 
     >>> def check_cache_size(cache, expected):
     ...     actual = cache.total_estimated_size

--- a/src/ZODB/tests/testConnection.py
+++ b/src/ZODB/tests/testConnection.py
@@ -230,6 +230,7 @@ class UserMethodTests(unittest.TestCase):
 
         >>> db = databaseFromString("<zodb>\n<mappingstorage/>\n</zodb>")
         >>> cn = db.open()
+        >>> cn.cacheMinimize() # See fix84.rst
         >>> obj = cn.get(p64(0))
         >>> obj._p_oid
         '\x00\x00\x00\x00\x00\x00\x00\x00'

--- a/src/ZODB/tests/testDB.py
+++ b/src/ZODB/tests/testDB.py
@@ -125,7 +125,7 @@ def connectionDebugInfo():
     r"""DB.connectionDebugInfo provides information about connections.
 
     >>> import time
-    >>> now = 1228423244.5
+    >>> now = 1228423244.1
     >>> def faux_time():
     ...     global now
     ...     now += .1
@@ -154,8 +154,8 @@ def connectionDebugInfo():
     >>> before = [x['before'] for x in info]
     >>> opened = [x['opened'] for x in info]
     >>> infos = [x['info'] for x in info]
-    >>> before
-    [None, '\x03zY\xd8\xc0m9\xdd', None]
+    >>> before == [None, c1.root()._p_serial, None]
+    True
     >>> opened
     ['2008-12-04T20:40:44Z (1.30s)', '2008-12-04T20:40:46Z (0.10s)', None]
     >>> infos
@@ -351,6 +351,7 @@ def minimally_test_connection_timeout():
 
     >>> db = ZODB.DB(None, pool_timeout=.01)
     >>> c1 = db.open()
+    >>> c1.cacheMinimize() # See fix84.rst
     >>> c2 = db.open()
     >>> c1.close()
     >>> c2.close()


### PR DESCRIPTION
This fixes #84.

Also:

- Added missing transaction ``begin`` call in the DB ``transaction()``
  context manager.

- Added the ability to add a transaction note whan calling
  ``transaction()``.  This is useful (as would be the ability to pass
  in other transaction meta data, but this was needed by (and this
  tested) to make an existing test pass.