### PR TITLE
Call _p_resolveConflict() even if a conflicting change doesn't change the state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
  Change History
 ================
 
+4.4.4 (unreleased)
+==================
+
+- Call _p_resolveConflict() even if a conflicting change doesn't change the
+  state. This reverts to the behaviour of 3.10.3 and older.
+
 4.4.3 (2016-08-04)
 ==================
 

--- a/src/ZODB/ConflictResolution.py
+++ b/src/ZODB/ConflictResolution.py
@@ -271,13 +271,6 @@ def tryToResolveConflict(self, oid, committedSerial, oldSerial, newpickle,
         if not committedData:
             committedData  = self.loadSerial(oid, committedSerial)
 
-        if newpickle == oldData:
-            # old -> new diff is empty, so merge is trivial
-            return committedData
-        if committedData == oldData:
-            # old -> committed diff is empty, so merge is trivial
-            return newpickle
-
         newstate = unpickler.load()
         old       = state(self, oid, oldSerial, prfactory, oldData)
         committed = state(self, oid, committedSerial, prfactory, committedData)


### PR DESCRIPTION
This fixes #97. See the docstring of the updated unit test for more explanation.