### PR TITLE
Don't raise an AttributeError when DemoStorage successfully stores a blob first.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
  Change History
 ================
 
+5.0.1 (unreleased)
+==================
+
+- Fix an AttributeError that DemoStorage could raise if it was asked
+  to store a blob into a temporary changes before reading a blob. See
+  `issue 103 <https://github.com/zopefoundation/ZODB/issues/103>`_.
+
 5.0.0 (2016-09-06)
 ==================
 

--- a/src/ZODB/DemoStorage.py
+++ b/src/ZODB/DemoStorage.py
@@ -379,10 +379,10 @@ class DemoStorage(ConflictResolvingStorage):
             self.changes.storeBlob(
                 oid, oldserial, data, blobfilename, '', transaction)
         except AttributeError:
-            if self._blobify():
-                self.changes.storeBlob(
-                    oid, oldserial, data, blobfilename, '', transaction)
-            raise
+            if not self._blobify():
+                raise
+            self.changes.storeBlob(
+                oid, oldserial, data, blobfilename, '', transaction)
 
     checkCurrentSerialInTransaction = (
         ZODB.BaseStorage.checkCurrentSerialInTransaction)

--- a/src/ZODB/DemoStorage.test
+++ b/src/ZODB/DemoStorage.test
@@ -286,6 +286,36 @@ storage wrapped around it when necessary:
 
     >>> db.close()
 
+This works even if we first write a blob rather than read a blob:
+
+    >>> base = ZODB.blob.BlobStorage('base',
+    ...                               FileStorage('base.fs', read_only=True))
+    >>> storage = DemoStorage(base=base)
+
+    >>> type(storage.changes).__name__
+    'MappingStorage'
+
+    >>> db = DB(storage)
+    >>> conn = db.open()
+
+    >>> _ = transaction.begin()
+    >>> conn.root()['blob'] = ZODB.blob.Blob()
+    >>> with conn.root()['blob'].open('w') as file:
+    ...     _ = file.write(b'state 2')
+    >>> transaction.commit()
+
+    >>> type(storage.changes).__name__
+    'BlobStorage'
+
+    >>> with conn.root()['blob'].open() as fp: fp.read()
+    'state 2'
+
+    >>> storage.temporaryDirectory() == storage.changes.temporaryDirectory()
+    True
+
+    >>> db.close()
+
+
 .. Check that the temporary directory is gone
 
    For now, it won't go until the storage does.


### PR DESCRIPTION
Includes a (previously) failing test case.

Fixes #103.