### PR TITLE
Enable using coverage and coveralls for coverage reporting.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,9 @@
 [run]
-# source = ...
-# omit = ...
-# cover_pylib = False
-# branch = True
+source = src/ZODB/
+parallel = true
+omit =
+	 src/ZODB/tests/*
+	 src/ZODB/scripts/tests/*
 
 [report]
 exclude_lines =

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ dist
 testing.log
 .eggs/
 .dir-locals.el
+htmlcov
+tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,22 @@ matrix:
         - os: linux
           python: 3.5
 install:
+    - pip install -U pip
     - pip install zc.buildout
     - buildout $BUILOUT_OPTIONS
 script:
-    - bin/test -v1j99
-    - if [[ $TRAVIS_PYTHON_VERSION != 'pypy3' ]]; then cd doc; make html; fi
+    - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then bin/coverage run bin/coverage-test -v1j99; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' || $TRAVIS_PYTHON_VERSION == 'pypy3' ]]; then bin/test -v1j99; fi
+    - if [[ $TRAVIS_PYTHON_VERSION != 'pypy3' ]]; then pushd doc; make html; popd; fi
+    - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then pip install coveralls; fi # install early enough to get into the cache
+after_success:
+  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then bin/coverage combine; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coveralls; fi
 notifications:
     email: false
 cache:
   directories:
+    - $HOME/.cache/pip
     - eggs
+before_cache:
+    - rm -f $HOME/.cache/pip/log/debug.log

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,6 +2,7 @@
 develop = .
 parts =
     test
+    coverage-test
     scripts
     sphinx
 
@@ -22,13 +23,18 @@ defaults = ['--all']
 
 [coverage-test]
 recipe = zc.recipe.testrunner
-eggs = ${test:eggs}
+working-directory = .
+eggs =
+    ${test:eggs}
+    coverage
 initialization =
   import os, tempfile
   try: os.mkdir('tmp')
   except: pass
   tempfile.tempdir = os.path.abspath('tmp')
-defaults = ['--coverage', '${buildout:directory}/coverage']
+  if 'COVERAGE_PROCESS_START' not in os.environ: os.environ['COVERAGE_PROCESS_START'] = '.coveragerc'
+  else: import coverage; coverage.process_startup()
+defaults = ['--all']
 
 [coverage-report]
 recipe = zc.recipe.egg
@@ -39,7 +45,8 @@ arguments = ('${buildout:directory}/coverage',
 
 [scripts]
 recipe = zc.recipe.egg
-eggs = ${test:eggs}
+eggs =
+    ${coverage-test:eggs}
 interpreter = py
 
 [sphinx]


### PR DESCRIPTION
Set this up on travis.

This was just slightly tricky because of the use of 'j99' in the call to bin/test.