### PR TITLE
Remove obsolete code

### DIFF
--- a/src/ZODB/FileStorage/format.py
+++ b/src/ZODB/FileStorage/format.py
@@ -85,11 +85,10 @@
 
 import logging
 import struct
-import sys
 
 from ZODB.POSException import POSKeyError
 from ZODB.utils import u64, oid_repr, as_bytes
-
+from ZODB._compat import PY3
 
 class CorruptedError(Exception):
     pass
@@ -245,7 +244,7 @@ class DataHeader(object):
         if vlen:
             raise ValueError(
                 "Non-zero version length. Versions aren't supported.")
-        
+
         self.oid = oid
         self.tid = tid
         self.prev = prev
@@ -262,7 +261,7 @@ class DataHeader(object):
 
 def TxnHeaderFromString(s):
     res = TxnHeader(*struct.unpack(TRANS_HDR, s))
-    if sys.version_info[0] >= 3:
+    if PY3:
         res.status = res.status.decode('ascii')
     return res
 

--- a/src/ZODB/_compat.py
+++ b/src/ZODB/_compat.py
@@ -82,7 +82,7 @@ def PersistentPickler(persistent_id, *args, **kwargs):
     This covers the differences between Python 2 and 3 and PyPy/zodbpickle.
     """
     p = Pickler(*args, **kwargs)
-    if sys.version_info[0] < 3:
+    if not PY3:
         p.inst_persistent_id = persistent_id
 
     # PyPy uses a python implementation of cPickle/zodbpickle in both Python 2

--- a/src/ZODB/blob.py
+++ b/src/ZODB/blob.py
@@ -36,9 +36,10 @@ from ZODB._compat import PersistentUnpickler
 from ZODB._compat import decodebytes
 from ZODB._compat import ascii_bytes
 from ZODB._compat import INT_TYPES
+from ZODB._compat import PY3
 
 
-if sys.version_info[0] >= 3:
+if PY3:
     from io import FileIO as file
 
 

--- a/src/ZODB/tests/IteratorStorage.py
+++ b/src/ZODB/tests/IteratorStorage.py
@@ -24,7 +24,6 @@ from ZODB.utils import U64, p64, load_current
 
 from transaction import Transaction
 
-import sys
 import ZODB.blob
 
 try:
@@ -159,10 +158,8 @@ class IteratorStorage(IteratorCompare):
         # We store another transaction with 1 object, the already running
         # iterator does not pick this up.
         self._dostore()
-        if sys.version_info[0] < 3:
-            self.assertRaises(StopIteration, iterator.next)
-        else:
-            self.assertRaises(StopIteration, iterator.__next__)
+        with self.assertRaises(StopIteration):
+            next(iterator)
 
 
 class ExtendedIteratorStorage(IteratorCompare):

--- a/src/ZODB/tests/testCache.py
+++ b/src/ZODB/tests/testCache.py
@@ -33,7 +33,6 @@ import ZODB
 import ZODB.MappingStorage
 import ZODB.tests.util
 
-PY2 = sys.version_info[0] == 2
 
 class CacheTestBase(ZODB.tests.util.TestCase):
 

--- a/src/ZODB/tests/testDB.py
+++ b/src/ZODB/tests/testDB.py
@@ -227,63 +227,62 @@ def open_convenience():
 
     """
 
-if sys.version_info >= (2, 6):
-    def db_with_transaction():
-        """Using databases with with
+def db_with_transaction():
+    """Using databases with with
 
-        The transaction method returns a context manager that when entered
-        starts a transaction with a private transaction manager.  To
-        illustrate this, we start a trasnaction using a regular connection
-        and see that it isn't automatically committed or aborted as we use
-        the transaction context manager.
+    The transaction method returns a context manager that when entered
+    starts a transaction with a private transaction manager.  To
+    illustrate this, we start a trasnaction using a regular connection
+    and see that it isn't automatically committed or aborted as we use
+    the transaction context manager.
 
-        >>> db = ZODB.tests.util.DB()
-        >>> conn = db.open()
-        >>> conn.root()['x'] = conn.root().__class__()
-        >>> transaction.commit()
-        >>> conn.root()['x']['x'] = 1
+    >>> db = ZODB.tests.util.DB()
+    >>> conn = db.open()
+    >>> conn.root()['x'] = conn.root().__class__()
+    >>> transaction.commit()
+    >>> conn.root()['x']['x'] = 1
 
-        >>> with db.transaction() as conn2:
-        ...     conn2.root()['y'] = 1
+    >>> with db.transaction() as conn2:
+    ...     conn2.root()['y'] = 1
 
-        >>> conn2.opened
+    >>> conn2.opened
 
-    Now, we'll open a 3rd connection a verify that
+Now, we'll open a 3rd connection a verify that
 
-        >>> conn3 = db.open()
-        >>> conn3.root()['x']
-        {}
-        >>> conn3.root()['y']
-        1
-        >>> conn3.close()
+    >>> conn3 = db.open()
+    >>> conn3.root()['x']
+    {}
+    >>> conn3.root()['y']
+    1
+    >>> conn3.close()
 
-    Let's try again, but this time, we'll have an exception:
+Let's try again, but this time, we'll have an exception:
 
-        >>> with db.transaction() as conn2:
-        ...     conn2.root()['y'] = 2
-        ...     XXX #doctest: +IGNORE_EXCEPTION_DETAIL
-        Traceback (most recent call last):
-        ...
-        NameError: name 'XXX' is not defined
+    >>> with db.transaction() as conn2:
+    ...     conn2.root()['y'] = 2
+    ...     XXX #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ...
+    NameError: name 'XXX' is not defined
 
-        >>> conn2.opened
+    >>> conn2.opened
 
-        >>> conn3 = db.open()
-        >>> conn3.root()['x']
-        {}
-        >>> conn3.root()['y']
-        1
-        >>> conn3.close()
+    >>> conn3 = db.open()
+    >>> conn3.root()['x']
+    {}
+    >>> conn3.root()['y']
+    1
+    >>> conn3.close()
 
-        >>> transaction.commit()
+    >>> transaction.commit()
 
-        >>> conn3 = db.open()
-        >>> conn3.root()['x']
-        {'x': 1}
+    >>> conn3 = db.open()
+    >>> conn3.root()['x']
+    {'x': 1}
 
 
-        >>> db.close()
-        """
+    >>> db.close()
+    """
 
 def connection_allows_empty_version_for_idiots():
     r"""

--- a/src/ZODB/tests/testPersistentList.py
+++ b/src/ZODB/tests/testPersistentList.py
@@ -13,11 +13,11 @@
 ##############################################################################
 """Test the list interface to PersistentList
 """
-import sys
+
 import unittest
 from persistent.list import PersistentList
 
-PY2 = sys.version_info[0] == 2
+from six import PY2
 
 l0 = []
 l1 = [0]
@@ -84,7 +84,7 @@ class TestPList(unittest.TestCase):
         except IndexError:
             pass
         else:
-            raise TestFailed("uu2[2] shouldn't be assignable")
+            self.fail("uu2[2] shouldn't be assignable")
 
         # Test __delitem__
 
@@ -95,7 +95,7 @@ class TestPList(unittest.TestCase):
         except IndexError:
             pass
         else:
-            raise TestFailed("uu2[0] shouldn't be deletable")
+            self.fail("uu2[0] shouldn't be deletable")
 
         # Test __getslice__
 
@@ -191,7 +191,7 @@ class TestPList(unittest.TestCase):
         except ValueError:
             pass
         else:
-            raise TestFailed("expected ValueError")
+            self.fail("expected ValueError")
 
         # Test reverse
 

--- a/src/ZODB/tests/util.py
+++ b/src/ZODB/tests/util.py
@@ -19,7 +19,6 @@ import atexit
 import os
 import persistent
 import re
-import sys
 import tempfile
 import time
 import transaction
@@ -136,9 +135,6 @@ class AAAA_Test_Runner_Hack(unittest.TestCase):
         pass
 
 def assert_warning(category, func, warning_text=''):
-    if sys.version_info < (2, 6):
-        return func() # Can't use catch_warnings :(
-
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('default')
         result = func()
@@ -154,7 +150,7 @@ def assert_deprecated(func, warning_text=''):
 def wait(func=None, timeout=30):
     if func is None:
         return lambda f: wait(f, timeout)
-    for i in range(int(timeout*100)):
+    for _ in range(int(timeout*100)):
         if func():
             return
         time.sleep(.01)

--- a/src/ZODB/utils.py
+++ b/src/ZODB/utils.py
@@ -17,7 +17,6 @@ import struct
 import sys
 import time
 import threading
-import warnings
 from binascii import hexlify, unhexlify
 from struct import pack, unpack
 from tempfile import mkstemp
@@ -42,35 +41,9 @@ __all__ = ['z64',
            'tid_repr',
            'positive_id',
            'readable_tid_repr',
-           'DEPRECATED_ARGUMENT',
-           'deprecated37',
-           'deprecated38',
            'get_pickle_metadata',
            'locked',
           ]
-
-# A unique marker to give as the default value for a deprecated argument.
-# The method should then do a
-#
-#     if that_arg is not DEPRECATED_ARGUMENT:
-#         complain
-#
-# dance.
-DEPRECATED_ARGUMENT = object()
-
-# Raise DeprecationWarning, noting that the deprecated thing will go
-# away in ZODB 3.7.  Point to the caller of our caller (i.e., at the
-# code using the deprecated thing).
-def deprecated37(msg):
-    warnings.warn("This will be removed in ZODB 3.7:\n%s" % msg,
-                  DeprecationWarning, stacklevel=3)
-
-# Raise DeprecationWarning, noting that the deprecated thing will go
-# away in ZODB 3.8.  Point to the caller of our caller (i.e., at the
-# code using the deprecated thing).
-def deprecated38(msg):
-    warnings.warn("This will be removed in ZODB 3.8:\n%s" % msg,
-                  DeprecationWarning, stacklevel=3)
 
 
 if PY2:
@@ -187,7 +160,7 @@ tid_repr = serial_repr
 # for 8-byte string tid b'\x03D\x14"\x94\x8bC\x99'.
 def readable_tid_repr(tid):
     result = tid_repr(tid)
-    if isinstance(tid, str) and len(tid) == 8:
+    if isinstance(tid, bytes) and len(tid) == 8:
         result = "%s %s" % (result, TimeStamp(tid))
     return result
 
@@ -318,7 +291,8 @@ class locked(object):
         return Locked(func, preconditions=self.preconditions)
 
 
-if os.environ.get('DEBUG_LOCKING'):
+if os.environ.get('DEBUG_LOCKING'): # pragma: no cover
+    # NOTE: This only works on Python 3.
     class Lock:
 
         lock_class = threading.Lock

--- a/src/ZODB/utils.py
+++ b/src/ZODB/utils.py
@@ -28,6 +28,8 @@ from ZODB._compat import Unpickler
 from ZODB._compat import BytesIO
 from ZODB._compat import ascii_bytes
 
+from six import PY2
+
 __all__ = ['z64',
            'p64',
            'u64',
@@ -71,7 +73,7 @@ def deprecated38(msg):
                   DeprecationWarning, stacklevel=3)
 
 
-if sys.version_info[0] < 3:
+if PY2:
     def as_bytes(obj):
         "Convert obj into bytes"
         return str(obj)


### PR DESCRIPTION
To help coverage numbers.

- Remove version tests for < 2.6. This removes some code and dedents/clarifies some other. (2.6 is unsupported. 2.5 is even longer unsupported). (The `w=0`  URL query argument can help make the diff cleaner in the dedent case.)
- Consistently spell remaining version checks as PY2 or PY3 for ease of finding them.
- Remove utils.deprecated3[78]. These haven't been used in a long time.