### PR TITLE
Cleaned up check_checkCurrentSerialInTransaction

### DIFF
--- a/doc/guide/transactions-and-threading.rst
+++ b/doc/guide/transactions-and-threading.rst
@@ -187,7 +187,7 @@ So, for example, if we wanted to set a transaction note::
 .. -> src
 
    >>> exec(src)
-   >>> db.history(conn.root()._p_oid)[0]['description']
+   >>> str(db.history(conn.root()._p_oid)[0]['description'])
    'incrementing x again'
 
 Here, we used the

--- a/src/ZODB/tests/BasicStorage.py
+++ b/src/ZODB/tests/BasicStorage.py
@@ -233,8 +233,8 @@ class BasicStorage:
             self._storage.checkCurrentSerialInTransaction(oid, tid, t)
             self._storage.tpc_vote(t)
         except POSException.ReadConflictError as v:
-            self.assertTrue(v.oid) == oid
-            self.assertTrue(v.serials == (tid2, tid))
+            self.assertEqual(v.oid, oid)
+            self.assertEqual(v.serials, (tid2, tid))
         else:
             if 0: self.assertTrue(False, "No conflict error")
 


### PR DESCRIPTION
- Use assertEqual rather than assertTrue for better error messages.

- Fixed a typo that caused an assertion to be missed.