### PR TITLE
Allow creating ghosts with data from search results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,10 @@
  Change History
 ================
 
+- The connection ``get`` method now accept an optional class pickle as
+  a second argument.  This is a somewhat experimental feature to
+  support index and search of objects in external indexes.
+
 5.1.1 (2016-11-18)
 ==================
 

--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -227,7 +227,7 @@ class Connection(ExportImport, object):
         # registered with the transaction.
         self._added[oid] = obj
 
-    def get(self, oid):
+    def get(self, oid, class_pickle=None):
         """Return the persistent object with oid 'oid'."""
         if self.opened is None:
             raise ConnectionStateError("The database connection is closed")
@@ -242,7 +242,10 @@ class Connection(ExportImport, object):
         if obj is not None:
             return obj
 
-        p, _ = self._storage.load(oid)
+        if class_pickle is None:
+            p, _ = self._storage.load(oid)
+        else:
+            p = class_pickle
         obj = self._reader.getGhost(p)
 
         # Avoid infiniate loop if obj tries to load its state before

--- a/src/ZODB/interfaces.py
+++ b/src/ZODB/interfaces.py
@@ -136,7 +136,7 @@ class IConnection(Interface):
         Raises ConnectionStateError if the connection is closed.
         """
 
-    def get(oid):
+    def get(oid, class_pickle=None):
         """Return the persistent object with oid 'oid'.
 
         If the object was not in the cache and the object's class is
@@ -148,7 +148,20 @@ class IConnection(Interface):
         are loaded transparently during attribute lookup.
 
         Parameters:
-        oid: an object id
+
+        oid
+          The id of the object to be returned
+
+        class_pickle
+          An optional pickle used to create a ghost object.  It's
+          normally not provided, but is obtained by loading the
+          object's data record from storage.
+
+          If provided then nothing is loaded from the storage and the
+          object id and class aren't checked.
+
+          This argument is intended to support indexing of objects in
+          external indexes.
 
         Raises KeyError if oid does not exist.
 

--- a/src/ZODB/tests/testConnection.py
+++ b/src/ZODB/tests/testConnection.py
@@ -1326,10 +1326,28 @@ class StubDatabase:
 
     large_record_size = 1<<30
 
+class ConnectionTests(unittest.TestCase):
+    # There are too many test classes. Let's put new unit tests here
+
+    def test_get_ghost_from_pickle(self):
+        # Get accepts an optional pickle argument to create a ghost
+        # without loading data.  This is useful when external indexes
+        # are used to index objects and we want to create ghosts for
+        # results.
+        import ZODB
+        conn = ZODB.connection(None)
+
+        oid = p64(42)
+        ob = conn.get(oid, b'cpersistent.mapping\nPersistentMapping\n.')
+        self.assertEqual(ob._p_oid, oid)
+        from persistent.mapping import PersistentMapping
+        self.assertEqual(ob.__class__, PersistentMapping)
+
 def test_suite():
     s = unittest.makeSuite(ConnectionDotAdd)
     s.addTest(unittest.makeSuite(SetstateErrorLoggingTests))
     s.addTest(doctest.DocTestSuite(checker=checker))
     s.addTest(unittest.makeSuite(TestConnectionInterface))
     s.addTest(unittest.makeSuite(EstimatedSizeTests))
+    s.addTest(unittest.makeSuite(ConnectionTests))
     return s


### PR DESCRIPTION
The connection get method now accept an optional class pickle as  a second argument.  This is a somewhat experimental feature to support index and search of objects in external indexes.