### PR TITLE
Fix deadlock with storages that "sync" on a new transaction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,10 +7,14 @@
 
 - ``persistent`` is no longer required at setup time.
   See `issue 119 <https://github.com/zopefoundation/ZODB/issues/119>`_.
+
 - ``Connection.close`` and ``Connection.open`` no longer race on
   ``self.transaction_manager``, which could lead to
   ``AttributeError``. This was a bug introduced in 5.0.1. See `issue
   142 <https://github.com/zopefoundation/ZODB/pull/143>`_.
+
+- Fix deadlock with storages that "sync" on a new transaction.
+  https://github.com/zopefoundation/ZODB/pull/136
 
 4.4.4 (2016-11-27)
 ==================

--- a/src/ZODB/DB.py
+++ b/src/ZODB/DB.py
@@ -753,18 +753,15 @@ class DB(object):
                     result = self.pool.pop()
             assert result is not None
 
-            # open the connection.
-            result.open(transaction_manager)
-
             # A good time to do some cache cleanup.
             # (note we already have the lock)
             self.pool.availableGC()
             self.historical_pool.availableGC()
-
-            return result
-
         finally:
             self._r()
+
+        result.open(transaction_manager)
+        return result
 
     def connectionDebugInfo(self):
         result = []

--- a/src/ZODB/tests/testDB.py
+++ b/src/ZODB/tests/testDB.py
@@ -151,7 +151,7 @@ def connectionDebugInfo():
     >>> before
     [None, '\x03zY\xd8\xc0m9\xdd', None]
     >>> opened
-    ['2008-12-04T20:40:44Z (1.40s)', '2008-12-04T20:40:45Z (0.30s)', None]
+    ['2008-12-04T20:40:44Z (1.30s)', '2008-12-04T20:40:46Z (0.10s)', None]
     >>> infos
     ['test info (2)', ' (0)', ' (0)']
 


### PR DESCRIPTION
This backports a change from commit 227953b977a9e195c4ce9bbb9acd9c5ee60c333a.

NEO, as well as ZEO+server_sync (ERP5 backports this feature with a monkey-patch), pings the server (primary master node in the case of NEO) on new transactions. However, this round-trip is actually performed by the thread that also does tasks requiring to lock the DB, like processing of invalidations.

Since transaction 1.6.1 (more precisely zopefoundation/transaction@e581a120a612d54eea9240606a5723ff73952eb0), IStorage.sync() is called indirectly by DB.open() when a transaction has already begun, and the DB must not be locked when this happens.