### PR TITLE
Connection.new_oid delegates to its storage, not the DB.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,5 +8,6 @@ omit =
 [report]
 exclude_lines =
     pragma: nocover
+    pragma: no cover
     if __name__ == ['"]__main__['"]:
     assert False

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
  Change History
 ================
 
+5.1.2 (unreleased)
+==================
+
+- ``Connection.new_oid`` delegates to its storage, not the DB. This is
+  helpful for improving concurrency in MVCC storages like RelStorage.
+  See `issue 139 <https://github.com/zopefoundation/ZODB/issues/139`_.
+
 5.1.1 (2016-11-18)
 ==================
 

--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -126,7 +126,6 @@ class Connection(ExportImport, object):
             storage = storage.new_instance()
 
         self._normal_storage = self._storage = storage
-        self.new_oid = db.new_oid
         self._savepoint_storage = None
 
         # Do we need to join a txn manager?
@@ -199,6 +198,9 @@ class Connection(ExportImport, object):
         self._import = None
 
         self._reader = ObjectReader(self, self._cache, self._db.classFactory)
+
+    def new_oid(self):
+        return self._storage.new_oid()
 
     def add(self, obj):
         """Add a new object 'obj' to the database and assign it an oid."""

--- a/src/ZODB/DB.py
+++ b/src/ZODB/DB.py
@@ -987,7 +987,13 @@ class DB(object):
         return ContextManager(self, note)
 
     def new_oid(self):
-        return self.storage.new_oid()
+        """
+        Return a new oid from the storage.
+
+        Kept for backwards compatibility only. New oids should be
+        allocated in a transaction using an open Connection.
+        """
+        return self.storage.new_oid() # pragma: no cover
 
     def open_then_close_db_when_connection_closes(self):
         """Create and return a connection.


### PR DESCRIPTION
Fixes #139