### PR TITLE
Don't require persistent at setup time. We don't build native code th…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@
 - ``Connection.new_oid`` delegates to its storage, not the DB. This is
   helpful for improving concurrency in MVCC storages like RelStorage.
   See `issue 139 <https://github.com/zopefoundation/ZODB/issues/139`_.
+- ``persistent`` is no longer required at setup time.
+  See `issue 119 <https://github.com/zopefoundation/ZODB/issues/119>`_.
 
 5.1.1 (2016-11-18)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,6 @@ tests_require = ['zope.testing', 'manuel']
 
 setup(name="ZODB",
       version=version,
-      setup_requires=['persistent'],
       author="Jim Fulton",
       author_email="jim@zope.com",
       maintainer="Zope Foundation and Contributors",


### PR DESCRIPTION
…at needs those headers anymore. Fixes #119.