### PR TITLE
Notify storages that transactions have completed.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,14 +2,23 @@
  Change History
 ================
 
-5.1.2 (unreleased)
+5.2.0 (unreleased)
 ==================
+
+- Call new afterCompletion API on storages to allow them to free
+  resources after transaction complete.  See:
+  https://github.com/zodb/relstorage/issues/147
+
+- Take advantage of the new transaction-manager explicit mode to avoid
+  starting transactions unnecessarily when transactions end.
 
 - ``Connection.new_oid`` delegates to its storage, not the DB. This is
   helpful for improving concurrency in MVCC storages like RelStorage.
   See `issue 139 <https://github.com/zopefoundation/ZODB/issues/139`_.
+
 - ``persistent`` is no longer required at setup time.
   See `issue 119 <https://github.com/zopefoundation/ZODB/issues/119>`_.
+
 - ``Connection.close`` and ``Connection.open`` no longer race on
   ``self.transaction_manager``, which could lead to
   ``AttributeError``. This was a bug introduced in 5.0.1. See `issue

--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -746,9 +746,6 @@ class Connection(ExportImport, object):
         except AttributeError:
             assert self._storage is None
 
-        # Now is a good time to collect some garbage.
-        self._cache.incrgc()
-
     def afterCompletion(self, transaction):
         # Note that we we call newTransaction here for 2 reasons:
         # a) Applying invalidations early frees up resources
@@ -763,6 +760,9 @@ class Connection(ExportImport, object):
 
         if not self.explicit_transactions:
             self.newTransaction(transaction, False)
+
+        # Now is a good time to collect some garbage.
+        self._cache.incrgc()
 
     # Transaction-manager synchronization -- ISynchronizer
     ##########################################################################

--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -902,22 +902,25 @@ class Connection(ExportImport, object):
             # New code is in place.  Start a new cache.
             self._resetCache()
 
-        # This newTransaction is to deal with some pathalogical cases:
-        #
-        # a) Someone opens a connection when a transaction isn't
-        #    active and proceeeds without calling begin on a
-        #    transaction manager. We initialize the transaction for
-        #    the connection, but we don't do a storage sync, since
-        #    this will be done if a well-nehaved application calls
-        #    begin, and we don't want to penalize well-behaved
-        #    transactions by syncing twice, as storage syncs might be
-        #    expensive.
-        # b) Lots of tests assume that connection transaction
-        #    information is set on open.
-        #
-        # Fortunately, this is a cheap operation.  It doesn't really
-        # cost much, if anything.
-        self.newTransaction(None, False)
+        if not self.explicit_transactions:
+            # This newTransaction is to deal with some pathalogical cases:
+            #
+            # a) Someone opens a connection when a transaction isn't
+            #    active and proceeeds without calling begin on a
+            #    transaction manager. We initialize the transaction for
+            #    the connection, but we don't do a storage sync, since
+            #    this will be done if a well-nehaved application calls
+            #    begin, and we don't want to penalize well-behaved
+            #    transactions by syncing twice, as storage syncs might be
+            #    expensive.
+            # b) Lots of tests assume that connection transaction
+            #    information is set on open.
+            #
+            # Fortunately, this is a cheap operation.  It doesn't
+            # really cost much, if anything.  Well, except for
+            # RelStorage, in which case it adds a server round
+            # trip.
+            self.newTransaction(None, False)
 
         transaction_manager.registerSynch(self)
 

--- a/src/ZODB/interfaces.py
+++ b/src/ZODB/interfaces.py
@@ -1243,6 +1243,16 @@ class IMVCCPrefetchStorage(IMVCCStorage):
         more than once.
         """
 
+class IMVCCAfterCompletionStorage(IMVCCStorage):
+
+    def afterCompletion():
+        """Notify a storage that a transaction has ended.
+
+        The storage may choose to use this opportunity to release resources.
+
+        See ``transaction.interfaces.ISynchronizer.afterCompletion``.
+        """
+
 class IStorageCurrentRecordIteration(IStorage):
 
     def record_iternext(next=None):

--- a/src/ZODB/tests/testConnection.py
+++ b/src/ZODB/tests/testConnection.py
@@ -1341,6 +1341,7 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(len(syncs), 2)
         conn.transaction_manager.abort()
         self.assertEqual(len(syncs), 2)
+        conn.close()
         db.close()
 
         # For reference, in non-explicit mode:
@@ -1351,6 +1352,8 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(len(syncs), 3)
         conn.transaction_manager.abort()
         self.assertEqual(len(syncs), 4)
+        conn.close()
+        db.close()
 
 class StubDatabase:
 

--- a/src/ZODB/tests/testConnection.py
+++ b/src/ZODB/tests/testConnection.py
@@ -1060,6 +1060,7 @@ def doctest_lp485456_setattr_in_setstate_doesnt_cause_multiple_stores():
     >>> conn.close()
     """
 
+
 class _PlayPersistent(Persistent):
     def setValueWithSize(self, size=0): self.value = size*' '
     __init__ = setValueWithSize
@@ -1301,14 +1302,55 @@ class StubStorage:
         return z64
 
 
-class TestConnectionInterface(unittest.TestCase):
+class TestConnection(unittest.TestCase):
 
     def test_connection_interface(self):
         from ZODB.interfaces import IConnection
         db = databaseFromString("<zodb>\n<mappingstorage/>\n</zodb>")
         cn = db.open()
         verifyObject(IConnection, cn)
+        db.close()
 
+    def test_storage_afterCompletionCalled(self):
+        db = ZODB.DB(None)
+        conn = db.open()
+        data = []
+        conn._storage.afterCompletion = lambda : data.append(None)
+        conn.transaction_manager.commit()
+        self.assertEqual(len(data), 1)
+        conn.close()
+        self.assertEqual(len(data), 2)
+        db.close()
+
+    def test_explicit_transactions_no_newTransactuon_on_afterCompletion(self):
+        db = ZODB.DB(None)
+
+        # We don't want to depend on latest transaction package, so
+        # just set attr for test:
+        tm = transaction.TransactionManager()
+        tm.explicit = True
+
+        conn = db.open(tm)
+        syncs = []
+        conn._storage.sync = syncs.append
+        conn.transaction_manager.begin()
+        self.assertEqual(len(syncs), 1)
+        conn.transaction_manager.commit()
+        self.assertEqual(len(syncs), 1)
+        conn.transaction_manager.begin()
+        self.assertEqual(len(syncs), 2)
+        conn.transaction_manager.abort()
+        self.assertEqual(len(syncs), 2)
+        db.close()
+
+        # For reference, in non-explicit mode:
+        db = ZODB.DB(None)
+        conn = db.open()
+        conn._storage.sync = syncs.append
+        conn.transaction_manager.begin()
+        self.assertEqual(len(syncs), 3)
+        conn.transaction_manager.abort()
+        self.assertEqual(len(syncs), 4)
 
 class StubDatabase:
 
@@ -1330,6 +1372,6 @@ def test_suite():
     s = unittest.makeSuite(ConnectionDotAdd)
     s.addTest(unittest.makeSuite(SetstateErrorLoggingTests))
     s.addTest(doctest.DocTestSuite(checker=checker))
-    s.addTest(unittest.makeSuite(TestConnectionInterface))
+    s.addTest(unittest.makeSuite(TestConnection))
     s.addTest(unittest.makeSuite(EstimatedSizeTests))
     return s


### PR DESCRIPTION
See: https://github.com/zodb/relstorage/issues/147

- Call new afterCompletion API on storages to allow them to free
  resources after transaction complete.  See:
  https://github.com/zodb/relstorage/issues/147

- Take advantage of the new transaction-manager explicit mode to avoid
  starting transactions unnecessarily when transactions end.

This differs from the previous PR:

- No longer implement seatbelts, as the transaction package does that.

- No longer configure explicit mode via DB.  We get explicit mode from the transaction manager.
