### PR TITLE
FileStorage: Report problem on read-only open of non-existent file

### DIFF
--- a/src/ZODB/FileStorage/FileStorage.py
+++ b/src/ZODB/FileStorage/FileStorage.py
@@ -267,6 +267,10 @@ class FileStorage(
                 if exc.errno == errno.EFBIG:
                     # The file is too big to open.  Fail visibly.
                     raise
+                if read_only:
+                    # When open request is read-only we do not want to create
+                    # the file
+                    raise
                 if exc.errno == errno.ENOENT:
                     # The file doesn't exist.  Create it.
                     create = 1

--- a/src/ZODB/tests/testConfig.py
+++ b/src/ZODB/tests/testConfig.py
@@ -73,6 +73,16 @@ class ZODBConfigTest(ConfigTestBase):
 
     def test_file_config2(self):
         path = tempfile.mktemp()
+        # first pass to actually create database file
+        self._test(
+            """
+            <zodb>
+              <filestorage>
+                path %s
+              </filestorage>
+            </zodb>
+            """ % path)
+        # write operations must be disallowed on read-only access
         cfg = """
         <zodb>
           <filestorage>

--- a/src/ZODB/tests/testFileStorage.py
+++ b/src/ZODB/tests/testFileStorage.py
@@ -689,6 +689,19 @@ def pack_with_open_blob_files():
     >>> db.close()
     """
 
+def readonly_open_nonexistent_file():
+    """
+    Make sure error is reported when non-existent file is tried to be opened
+    read-only.
+
+    >>> try:
+    ...     fs = ZODB.FileStorage.FileStorage('nonexistent.fs', read_only=True)
+    ... except Exception as e:
+    ...     # Python2 raises IOError; Python3 - FileNotFoundError
+    ...     print("error: %s" % str(e)) # doctest: +ELLIPSIS
+    error: ... No such file or directory: 'nonexistent.fs'
+    """
+
 def test_suite():
     suite = unittest.TestSuite()
     for klass in [


### PR DESCRIPTION
... instead of silently creating empty database on such opens.

Use-case for this are utilities like e.g. zodbdump and zodbcmp which
expect such storage opens to fail so that the tool can know there is no
such storage and report it to user.

In contrast current state is: read-only opens get created-on-the-fly
empty storage with no content, but which can be iterated over without
getting any error.

This way e.g. `zodbdump non-existent.fs` produces empty output _and_
exit code 0 which is not what caller expects.