### PR TITLE
Fix PyPI page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,8 @@
 ==================
 
 - Fixed: When opening FileStorages in read-only mode, non-existent
-  files were silently created.  Creating a file-storage against a
-  non-existent file errors.
+  files were silently created.  Creating a read-only file-storage
+  against a non-existent file errors.
 
 5.2.0 (2017-02-09)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,14 +5,15 @@
 5.2.1 (unreleased)
 ==================
 
-- Nothing changed yet.
-
+- Fixed: When opening FileStorages in read-only mode, non-existent
+  files were silently created.  Creating a file-storage against a
+  non-existent file errors.
 
 5.2.0 (2017-02-09)
 ==================
 
 - Call new afterCompletion API on storages to allow them to free
-  resources after transaction complete.  
+  resources after transaction complete.
   See `issue 147 <https://github.com/zodb/relstorage/issues/147>`__.
 - Take advantage of the new transaction-manager explicit mode to avoid
   starting transactions unnecessarily when transactions end.

--- a/DEVELOPERS.rst
+++ b/DEVELOPERS.rst
@@ -1,0 +1,68 @@
+For developers of ZODB
+======================
+
+Building
+---------
+
+Bootstrap buildout, if necessary using ``bootstrap.py``::
+
+  python bootstrap.py
+
+Run the buildout::
+
+  bin/buildout
+
+Testing
+-------
+
+The ZODB checkouts are `buildouts <http://www.python.org/pypi/zc.buildout>`_.
+When working from a ZODB checkout, first run the bootstrap.py script
+to initialize the buildout:
+
+    % python bootstrap.py
+
+and then use the buildout script to build ZODB and gather the dependencies:
+
+    % bin/buildout
+
+This creates a test script:
+
+    % bin/test -v
+
+This command will run all the tests, printing a single dot for each
+test.  When it finishes, it will print a test summary.  The exact
+number of tests can vary depending on platform and available
+third-party libraries.::
+
+    Ran 1182 tests in 241.269s
+
+    OK
+
+The test script has many more options.  Use the ``-h`` or ``--help``
+options to see a file list of options.  The default test suite omits
+several tests that depend on third-party software or that take a long
+time to run.  To run all the available tests use the ``--all`` option.
+Running all the tests takes much longer.::
+
+    Ran 1561 tests in 1461.557s
+
+    OK
+
+Our primary development platforms are Linux and Mac OS X.  The test
+suite should pass without error on these platforms and, hopefully,
+Windows, although it can take a long time on Windows -- longer if you
+use ZoneAlarm.
+
+Generating docs
+---------------
+
+cd to the doc directory and::
+
+  make html
+
+Contributing
+------------
+
+Almost any code change should include tests.
+
+Any change that changes features should include documentation updates.

--- a/DEVELOPERS.rst
+++ b/DEVELOPERS.rst
@@ -1,8 +1,9 @@
+======================
 For developers of ZODB
 ======================
 
 Building
----------
+========
 
 Bootstrap buildout, if necessary using ``bootstrap.py``::
 
@@ -13,7 +14,7 @@ Run the buildout::
   bin/buildout
 
 Testing
--------
+=======
 
 The ZODB checkouts are `buildouts <http://www.python.org/pypi/zc.buildout>`_.
 When working from a ZODB checkout, first run the bootstrap.py script
@@ -54,14 +55,14 @@ Windows, although it can take a long time on Windows -- longer if you
 use ZoneAlarm.
 
 Generating docs
----------------
+===============
 
 cd to the doc directory and::
 
   make html
 
 Contributing
-------------
+============
 
 Almost any code change should include tests.
 

--- a/README.rst
+++ b/README.rst
@@ -19,3 +19,8 @@ high-degree of transparency.
 ZODB is an ACID Transactional database.
 
 To learn more, visit: http://www.zodb.org
+
+The githib repository is: at https://github.com/zopefoundation/zodb
+
+If you're interested in contributing to ZODB itself, see the
+`developer notes <DEVELOPERS.rst>`_.

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-====
-ZODB
-====
+=======================================
+ZODB, a Python object-oriented database
+=======================================
 
 ZODB provides an object-oriented database for Python that provides a
 high-degree of transparency.

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,8 @@ ZODB is an ACID Transactional database.
 
 To learn more, visit: http://www.zodb.org
 
-The githib repository is: at https://github.com/zopefoundation/zodb
+The github repository is: at https://github.com/zopefoundation/zodb
 
 If you're interested in contributing to ZODB itself, see the
-`developer notes <DEVELOPERS.rst>`_.
+`developer notes
+<https://github.com/zopefoundation/ZODB/blob/master/DEVELOPERS.rst>`_.

--- a/README.rst
+++ b/README.rst
@@ -2,112 +2,20 @@
 ZODB
 ====
 
-Introduction
-============
+ZODB provides an object-oriented database for Python that provides a
+high-degree of transparency.
 
-The ZODB  package provides a  set of tools  for using the  Zope Object
-Database (ZODB).
+- no separate language for database operations
 
-Our primary development platforms are Linux and Mac OS X.  The test
-suite should pass without error on these platforms and, hopefully,
-Windows, although it can take a long time on Windows -- longer if you
-use ZoneAlarm.
+- very little impact on your code to make objects persistent
 
-Compatibility
-=============
+- no database mapper that partially hides the database.
 
-ZODB 5 requires Python 2.7 (>= 2.7.9) or Python >= 3.3.
+  Using an object-relational mapping **is not** like using an
+  object-oriented database.
 
-Documentation
-=============
+- almost no seam between code and database.
 
-See http://zodb-docs.readthedocs.io/en/latest/
+ZODB is an ACID Transactional database.
 
-For developers of ZODB
-======================
-
-Building
----------
-
-Bootstrap buildout, if necessary using ``bootstrap.py``::
-
-  python bootstrap.py
-
-Run the buildout::
-
-  bin/buildout
-
-Testing
--------
-
-The ZODB checkouts are `buildouts <http://www.python.org/pypi/zc.buildout>`_.
-When working from a ZODB checkout, first run the bootstrap.py script
-to initialize the buildout:
-
-    % python bootstrap.py
-
-and then use the buildout script to build ZODB and gather the dependencies:
-
-    % bin/buildout
-
-This creates a test script:
-
-    % bin/test -v
-
-This command will run all the tests, printing a single dot for each
-test.  When it finishes, it will print a test summary.  The exact
-number of tests can vary depending on platform and available
-third-party libraries.::
-
-    Ran 1182 tests in 241.269s
-
-    OK
-
-The test script has many more options.  Use the ``-h`` or ``--help``
-options to see a file list of options.  The default test suite omits
-several tests that depend on third-party software or that take a long
-time to run.  To run all the available tests use the ``--all`` option.
-Running all the tests takes much longer.::
-
-    Ran 1561 tests in 1461.557s
-
-    OK
-
-Generating docs
----------------
-
-cd to the doc directory and::
-
-  make html
-
-Contributing
-------------
-
-Almost any code change should include tests.
-
-Any change that changes features should include documentation updates.
-
-Maintenance scripts
--------------------
-
-Several scripts are provided with the ZODB and can help for analyzing,
-debugging, checking for consistency, summarizing content, reporting space used
-by objects, doing backups, artificial load testing, etc.
-Look at the ZODB/script directory for more informations.
-
-License
-=======
-
-ZODB is distributed under the Zope Public License, an OSI-approved
-open source license.  Please see the LICENSE.txt file for terms and
-conditions.
-
-More information
-================
-
-See http://zodb.org/
-
-
-.. image:: https://badges.gitter.im/zopefoundation/ZODB.svg
-   :alt: Join the chat at https://gitter.im/zopefoundation/ZODB
-   :target: https://gitter.im/zopefoundation/ZODB?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+To learn more, visit: http://www.zodb.org

--- a/setup.py
+++ b/setup.py
@@ -11,15 +11,6 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-"""Zope Object Database: object database and persistence
-
-The Zope Object Database provides an object-oriented database for
-Python that provides a high-degree of transparency. Applications can
-take advantage of object database features with few, if any, changes
-to application logic.  ZODB includes features such as a plugable storage
-interface, rich transaction support, and undo.
-"""
-
 version = '5.2.1.dev0'
 
 import os
@@ -100,19 +91,11 @@ def alltests():
             _unittests_only(suite, mod.test_suite())
     return suite
 
-doclines = __doc__.split("\n")
-
-def read_file(*path):
-    base_dir = os.path.dirname(__file__)
-    file_path = (base_dir, ) + tuple(path)
-    with open(os.path.join(*file_path), 'rb') as file:
-        return file.read()
-
-long_description = str(
-    ("\n".join(doclines[2:]) + "\n\n" +
-     ".. contents::\n\n" +
-     read_file("README.rst").decode('latin-1')  + "\n\n" +
-     read_file("CHANGES.rst").decode('latin-1')))
+long_description = (
+    open("README.rst").read()  +
+    "\n\n" +
+    open("CHANGES.rst").read()
+    )
 
 tests_require = ['zope.testing', 'manuel']
 
@@ -128,7 +111,7 @@ setup(name="ZODB",
       url = 'http://www.zodb.org/',
       license = "ZPL 2.1",
       platforms = ["any"],
-      description = doclines[0],
+      description = long_description[1],
       classifiers = list(filter(None, classifiers.split("\n"))),
       long_description = long_description,
       test_suite="__main__.alltests", # to support "setup.py test"

--- a/setup.py
+++ b/setup.py
@@ -91,11 +91,11 @@ def alltests():
             _unittests_only(suite, mod.test_suite())
     return suite
 
-long_description = (
-    open("README.rst").read()  +
-    "\n\n" +
-    open("CHANGES.rst").read()
-    )
+def read(path):
+    with open(path) as f:
+        return f.read()
+
+long_description = read("README.rst")  + "\n\n" + read("CHANGES.rst")
 
 tests_require = ['zope.testing', 'manuel']
 
@@ -111,8 +111,8 @@ setup(name="ZODB",
       url = 'http://www.zodb.org/',
       license = "ZPL 2.1",
       platforms = ["any"],
-      description = long_description[1],
       classifiers = list(filter(None, classifiers.split("\n"))),
+      description = long_description.split('\n', 2)[1],
       long_description = long_description,
       test_suite="__main__.alltests", # to support "setup.py test"
       tests_require = tests_require,


### PR DESCRIPTION
I noticed the other day that the PyPI page for the current release is hosed WRT ReST:

https://pypi.python.org/pypi/ZODB/5.2.0

In fixing this, I realized that a lot of text was out of date and not well suited to a PyPI page, so I:

- Split developer info into a separate doc.

- Simplified the README and setup script.