### PR TITLE
Import warnings on demand.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 5.2.3 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix an import error. See `issue 158 <https://github.com/zopefoundation/ZODB/issues/158>`_.
 
 
 5.2.2 (2017-04-11)
@@ -14,7 +14,7 @@
 - Fixed: A blob misfeature set blob permissions so that blobs and blob
   directories were only readable by the database process owner, rather
   than honoring user-controlled permissions (e.g. ``umask``).
-
+  See `issue 155 <https://github.com/zopefoundation/ZODB/issues/155>`_.
 
 5.2.1 (2017-04-08)
 ==================
@@ -411,4 +411,3 @@ Bugs Fixed
 .. note::
    Please see https://github.com/zopefoundation/ZODB/blob/master/HISTORY.rst
    for older versions of ZODB.
-

--- a/src/ZODB/blob.py
+++ b/src/ZODB/blob.py
@@ -389,11 +389,13 @@ class FilesystemHelper:
                     (self.layout_name, self.base_dir, layout))
 
     def isSecure(self, path):
+        import warnings
         warnings.warn(
             "isSecure is deprecated. Permissions are no longer set by ZODB",
             DeprecationWarning, stacklevel=2)
 
     def checkSecure(self):
+        import warnings
         warnings.warn(
             "checkSecure is deprecated. Permissions are no longer set by ZODB",
             DeprecationWarning, stacklevel=2)


### PR DESCRIPTION
Fixes #158.

Those methods aren't tested by ZODB, apparently (but they are by RelStorage).