### PR TITLE
Backport from 4.0 and later

### DIFF
--- a/src/ZODB/blob.py
+++ b/src/ZODB/blob.py
@@ -68,7 +68,8 @@ class Blob(persistent.Persistent):
             raise TypeError('Blobs do not support subclassing.')
         self.__setstate__()
         if data is not None:
-            self.open('w').write(data)
+            with self.open('w') as f:
+                f.write(data)
 
     def __setstate__(self, state=None):
         # we use lists here because it will allow us to add and remove


### PR DESCRIPTION
Avoid waiting for GC to close file. Could explain some bug with RelStorage