### PR TITLE
In py3, dict_keys type has no attribute sort

### DIFF
--- a/src/ZODB/scripts/analyze.py
+++ b/src/ZODB/scripts/analyze.py
@@ -67,8 +67,7 @@ def report(rep):
     fmts = "%46s %7d %8dk %5.1f%% %7.2f" # summary format
     print(fmt % ("Class Name", "Count", "TBytes", "Pct", "AvgSize"))
     print(fmt % ('-'*46, '-'*7, '-'*9, '-'*5, '-'*7))
-    typemap = rep.TYPEMAP.keys()
-    typemap.sort()
+    typemap = sorted(rep.TYPEMAP.keys())
     cumpct = 0.0
     for t in typemap:
         pct = rep.TYPESIZE[t] * 100.0 / rep.DBYTES


### PR DESCRIPTION
Using `ZODB.scripts.analyze` under python3, I ran into the follow issue:

```  File "/usr/local/lib/python3.5/dist-packages/ZODB/scripts/analyze.py", line 71, in report
    typemap.sort()
AttributeError: 'dict_keys' object has no attribute 'sort'
```

This commit uses the builtin `sorted` function instead.