### PR TITLE
Add support for 3.6, drop 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 matrix:
     include:
         - os: linux
-          python: pypy-5.4.1
+          python: pypy-5.6.0
         - os: linux
-          python: pypy3
+          python: pypy3.3-5.5-alpha
           env: BUILOUT_OPTIONS=sphinx:eggs=
         - os: linux
           python: 2.7
@@ -15,14 +15,16 @@ matrix:
           python: 3.4
         - os: linux
           python: 3.5
+        - os: linux
+          python: 3.6
 install:
     - pip install -U pip
     - pip install zc.buildout
     - buildout $BUILOUT_OPTIONS versions:sphinx=1.4.9
 script:
     - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then bin/coverage run bin/coverage-test -v1j99; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' || $TRAVIS_PYTHON_VERSION == 'pypy3' ]]; then bin/test -v1j99; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != 'pypy3' ]]; then pushd doc; make html; popd; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then bin/test -v1j99; fi
+    - if [[ $TRAVIS_PYTHON_VERSION != pypy3* ]]; then pushd doc; make html; popd; fi
     - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then pip install coveralls; fi # install early enough to get into the cache
 after_success:
   - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then bin/coverage combine; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
         - os: linux
           python: 2.7
         - os: linux
-          python: 3.3
-        - os: linux
           python: 3.4
         - os: linux
           python: 3.5
@@ -20,7 +18,7 @@ matrix:
 install:
     - pip install -U pip
     - pip install zc.buildout
-    - buildout $BUILOUT_OPTIONS versions:sphinx=1.4.9
+    - buildout $BUILOUT_OPTIONS
 script:
     - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then bin/coverage run bin/coverage-test -v1j99; fi
     - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then bin/test -v1j99; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 script:
     - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then bin/coverage run bin/coverage-test -v1j99; fi
     - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then bin/test -v1j99; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != pypy3* ]]; then pushd doc; make html; popd; fi
+    - if [[ $TRAVIS_PYTHON_VERSION != pypy3* ]]; then make -C doc html; fi
     - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then pip install coveralls; fi # install early enough to get into the cache
 after_success:
   - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then bin/coverage combine; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
           python: 3.6
 install:
     - pip install -U pip
-    - pip install zc.buildout
+    - pip install -U setuptools zc.buildout
     - buildout $BUILOUT_OPTIONS
 script:
     - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then bin/coverage run bin/coverage-test -v1j99; fi

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,12 @@
  Change History
 ================
 
-5.2.5 (unreleased)
+5.3.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Add support for Python 3.6.
+
+- Drop support for Python 3.3.
 
 
 5.2.4 (2017-05-17)

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,8 @@ ZODB, a Python object-oriented database
 =======================================
 
 ZODB provides an object-oriented database for Python that provides a
-high-degree of transparency.
+high-degree of transparency. ZODB runs on Python 2.7 or Python 3.3 and
+above. It also runs on PyPy.
 
 - no separate language for database operations
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ ZODB, a Python object-oriented database
 =======================================
 
 ZODB provides an object-oriented database for Python that provides a
-high-degree of transparency. ZODB runs on Python 2.7 or Python 3.3 and
+high-degree of transparency. ZODB runs on Python 2.7 or Python 3.4 and
 above. It also runs on PyPy.
 
 - no separate language for database operations

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,7 +16,7 @@ Because ZODB is an object database:
 
 Check out the :doc:`tutorial`!
 
-ZODB runs on Python 2.7 or Python 3.3 and above. It also runs on PyPy.
+ZODB runs on Python 2.7 or Python 3.4 and above. It also runs on PyPy.
 
 Transactions
 ============

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,6 +16,8 @@ Because ZODB is an object database:
 
 Check out the :doc:`tutorial`!
 
+ZODB runs on Python 2.7 or Python 3.3 and above. It also runs on PyPy.
+
 Transactions
 ============
 
@@ -201,7 +203,7 @@ Learning more
    reference/index
    articles/index
 
-* `The ZODB Book (in progress) <http://zodb.readthedocs.org/en/latest/>`_ 
+* `The ZODB Book (in progress) <http://zodb.readthedocs.org/en/latest/>`_
 
 Downloads
 =========

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '5.2.5.dev0'
+version = '5.3.0.dev0'
 
 classifiers = """\
 Intended Audience :: Developers
@@ -23,7 +23,6 @@ Programming Language :: Python
 Programming Language :: Python :: 2
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
@@ -145,5 +144,7 @@ setup(
       repozo = ZODB.scripts.repozo:main
     """,
     include_package_data=True,
+    # The pypy3 we test with on travis CI is still a Python 3.3
+    # implementation, so we don't explicitly blacklist 3.3 yet.
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
 )

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,10 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-version = '5.2.5.dev0'
-
 import os
 from setuptools import setup, find_packages
+
+version = '5.2.5.dev0'
 
 classifiers = """\
 Intended Audience :: Developers
@@ -79,7 +79,7 @@ def alltests():
     suite = unittest.TestSuite()
     base = pkg_resources.working_set.find(
         pkg_resources.Requirement.parse('ZODB')).location
-    for dirpath, dirnames, filenames in os.walk(base):
+    for dirpath, _dirnames, filenames in os.walk(base):
         if os.path.basename(dirpath) == 'tests':
             for filename in filenames:
                 if filename.endswith('.py') and filename.startswith('test'):
@@ -96,7 +96,7 @@ def read(path):
     with open(path) as f:
         return f.read()
 
-long_description = read("README.rst")  + "\n\n" + read("CHANGES.rst")
+long_description = read("README.rst") + "\n\n" + read("CHANGES.rst")
 
 tests_require = [
     'manuel',
@@ -104,27 +104,28 @@ tests_require = [
     'zope.testrunner >= 4.4.6',
 ]
 
-setup(name="ZODB",
-      version=version,
-      author="Jim Fulton",
-      author_email="jim@zope.com",
-      maintainer="Zope Foundation and Contributors",
-      maintainer_email="zodb-dev@zope.org",
-      keywords="database nosql python zope",
-      packages = find_packages('src'),
-      package_dir = {'': 'src'},
-      url = 'http://www.zodb.org/',
-      license = "ZPL 2.1",
-      platforms = ["any"],
-      classifiers = list(filter(None, classifiers.split("\n"))),
-      description = long_description.split('\n', 2)[1],
-      long_description = long_description,
-      test_suite="__main__.alltests", # to support "setup.py test"
-      tests_require = tests_require,
-      extras_require = {
+setup(
+    name="ZODB",
+    version=version,
+    author="Jim Fulton",
+    author_email="jim@zope.com",
+    maintainer="Zope Foundation and Contributors",
+    maintainer_email="zodb-dev@zope.org",
+    keywords="database nosql python zope",
+    packages=find_packages('src'),
+    package_dir={'': 'src'},
+    url='http://www.zodb.org/',
+    license="ZPL 2.1",
+    platforms=["any"],
+    classifiers=list(filter(None, classifiers.split("\n"))),
+    description=long_description.split('\n', 2)[1],
+    long_description=long_description,
+    test_suite="__main__.alltests", # to support "setup.py test"
+    tests_require=tests_require,
+    extras_require={
         'test': tests_require,
-      },
-      install_requires = [
+    },
+    install_requires=[
         'persistent >= 4.2.0',
         'BTrees >= 4.2.0',
         'ZConfig',
@@ -133,15 +134,15 @@ setup(name="ZODB",
         'zc.lockfile',
         'zope.interface',
         'zodbpickle >= 0.6.0',
-      ],
-      zip_safe = False,
-      entry_points = """
+    ],
+    zip_safe=False,
+    entry_points="""
       [console_scripts]
       fsdump = ZODB.FileStorage.fsdump:main
       fsoids = ZODB.scripts.fsoids:main
       fsrefs = ZODB.scripts.fsrefs:main
       fstail = ZODB.scripts.fstail:Main
       repozo = ZODB.scripts.repozo:main
-      """,
-      include_package_data = True,
-      )
+    """,
+    include_package_data=True,
+)

--- a/setup.py
+++ b/setup.py
@@ -145,4 +145,5 @@ setup(
       repozo = ZODB.scripts.repozo:main
     """,
     include_package_data=True,
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
 )

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ Programming Language :: Python :: 3
 Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
+Programming Language :: Python :: 3.6
 Programming Language :: Python :: Implementation :: CPython
 Programming Language :: Python :: Implementation :: PyPy
 Topic :: Database
@@ -97,7 +98,11 @@ def read(path):
 
 long_description = read("README.rst")  + "\n\n" + read("CHANGES.rst")
 
-tests_require = ['zope.testing', 'manuel']
+tests_require = [
+    'manuel',
+    'zope.testing',
+    'zope.testrunner >= 4.4.6',
+]
 
 setup(name="ZODB",
       version=version,

--- a/src/ZODB/tests/testdocumentation.py
+++ b/src/ZODB/tests/testdocumentation.py
@@ -33,7 +33,7 @@ def tearDown(test):
 
 def test_suite():
     base, src = os.path.split(os.path.dirname(os.path.dirname(ZODB.__file__)))
-    assert src == 'src'
+    assert src == 'src', src
     base = join(base, 'doc')
     guide = join(base, 'guide')
     reference = join(base, 'reference')
@@ -54,4 +54,3 @@ def test_suite():
 
 if __name__ == '__main__':
     unittest.main(defaultTest='test_suite')
-

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ commands =
     zope-testrunner -u --test-path=src []
 # Only run functional tests if unit tests pass.
     zope-testrunner -f --test-path=src []
-# without explicit deps, setup.py test will download a bunch of eggs into $PWD
 deps =
     .[test]
 
@@ -32,10 +31,9 @@ deps = {[testenv]deps}
 
 [testenv:coverage]
 basepython = python2.7
-usedevelop = true
 commands =
-    coverage run --source=ZODB -m zope.testrunner []
+    coverage run --source=ZODB -m zope.testrunner --test-path=src []
     coverage report
 deps =
-    coverage
     {[testenv]deps}
+    coverage

--- a/tox.ini
+++ b/tox.ini
@@ -2,19 +2,25 @@
 # Jython 2.7rc2 does work, but unfortunately has an issue running
 # with Tox 1.9.2 (http://bugs.jython.org/issue2325)
 #envlist = py26,py27,py33,py34,pypy,simple,jython,pypy3
-envlist = py27,py33,py34,py35,pypy,simple,pypy3
+envlist = py27,py33,py34,py35,py36,pypy,simple,pypy3
 
 [testenv]
+# ZODB.tests.testdocumentation needs to find
+# itself in the source tree to locate the doc/
+# directory. 'usedevelop' is more like what
+# buildout.cfg does, and is simpler than having
+# testdocumentation.py also understand how to climb
+# out of the tox site-packages.
+usedevelop = true
 commands =
 # Run unit tests first.
-    zope-testrunner -u --test-path=src --auto-color --auto-progress
+    zope-testrunner -u --test-path=src []
 # Only run functional tests if unit tests pass.
-    zope-testrunner -f --test-path=src --auto-color --auto-progress
+    zope-testrunner -f --test-path=src []
 # without explicit deps, setup.py test will download a bunch of eggs into $PWD
 deps =
-    manuel
-    zope.testing
-    zope.testrunner >= 4.4.6
+    .[test]
+
 
 [testenv:simple]
 # Test that 'setup.py test' works
@@ -28,7 +34,7 @@ deps = {[testenv]deps}
 basepython = python2.7
 usedevelop = true
 commands =
-    coverage run --source=ZODB -m zope.testrunner --test-path=src --auto-color --auto-progress
+    coverage run --source=ZODB -m zope.testrunner []
     coverage report
 deps =
     coverage

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # Jython 2.7rc2 does work, but unfortunately has an issue running
 # with Tox 1.9.2 (http://bugs.jython.org/issue2325)
 #envlist = py26,py27,py33,py34,pypy,simple,jython,pypy3
-envlist = py27,py33,py34,py35,py36,pypy,simple,pypy3
+envlist = py27,py34,py35,py36,pypy,simple,pypy3
 
 [testenv]
 # ZODB.tests.testdocumentation needs to find


### PR DESCRIPTION
- Fix running tests using tox.
- Whitespace cleanup in setup.py (spaces around operators and continuing indentation).
- Fix running tests on PyPy on Travis. (They were just being skipped.)
- Use latest PyPy versions on Travis.
- Add python_requires to setup metadata.
- Drop classifier and tests for Python 3.3 (though PyPy3 on Travis is still 3.3 so it is still technically being tested). This fixes #148.