### PR TITLE
Unpin specific PyPy versions, blacklist 3.3 in `setup.py`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 matrix:
     include:
         - os: linux
-          python: pypy-5.6.0
+          python: pypy
         - os: linux
-          python: pypy3.3-5.5-alpha
+          python: pypy3
           env: BUILOUT_OPTIONS=sphinx:eggs=
         - os: linux
           python: 2.7

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,5 @@ setup(
       repozo = ZODB.scripts.repozo:main
     """,
     include_package_data=True,
-    # The pypy3 we test with on travis CI is still a Python 3.3
-    # implementation, so we don't explicitly blacklist 3.3 yet.
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
 )


### PR DESCRIPTION
Unpin specific PyPy versions, blacklist 3.3 in `setup.py` as Travis now offers a new enough PyPy 3.