### PR TITLE
Report full oid of missing object during pack

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 5.3.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- If an object is missing from the index while packing a ``FileStorage``,
+  report its full ``oid``.
 
 
 5.3.0 (2017-08-30)

--- a/src/ZODB/FileStorage/fspack.py
+++ b/src/ZODB/FileStorage/fspack.py
@@ -270,7 +270,7 @@ class GC(FileStorageFormatter):
                 if oid == z64 and len(oid2curpos) == 0:
                     # special case, pack to before creation time
                     continue
-                raise
+                raise KeyError(oid)
 
             reachable[oid] = pos
             for oid in self.findrefs(pos):


### PR DESCRIPTION
@hvelarde had an issue with a db that couldn't be packed due to an object that could not be found. This makes sure that the entire oid is reported in that case, instead of just the final 2 bytes.

Or would it be better to handle this in `fsIndex`'s `__getitem__`?