### PR TITLE
Process invalidations immediately for closed connections

### DIFF
--- a/src/ZODB/tests/testConnection.py
+++ b/src/ZODB/tests/testConnection.py
@@ -567,6 +567,14 @@ class InvalidationTests(unittest.TestCase):
         >>> p3._p_state
         0
 
+        Invalidations are processed immediately by closed connections.
+
+        >>> cn.close()
+        >>> mvcc_storage.invalidate(p64(1), {p1._p_oid: 1})
+        >>> mvcc_instance.poll_invalidations()
+        []
+        >>> db.open() is cn
+        True
         >>> db.close()
         """
 


### PR DESCRIPTION
This fixes a memory leak when `pool-timeout` is not set.