### PR TITLE
Avoid seeking on import

### DIFF
--- a/src/ZODB/ExportImport.py
+++ b/src/ZODB/ExportImport.py
@@ -158,9 +158,15 @@ class ExportImport(object):
                 oids[ooid] = oid = self._storage.new_oid()
                 return_oid_list.append(oid)
 
-            # Blob support
-            blob_begin = f.read(len(blob_begin_marker))
-            if blob_begin == blob_begin_marker:
+            if (len(data) < 99 and 'blob' in data and
+                isinstance(self._reader.getGhost(data), Blob)
+                ):
+                # Blob support
+
+                # Make sure we have a (redundant, overly) blob marker.
+                if f.read(len(blob_begin_marker)) != blob_begin_marker:
+                    raise ValueError("No data for blob object")
+
                 # Copy the blob data to a temporary file
                 # and remember the name
                 blob_len = u64(f.read(8))
@@ -169,7 +175,6 @@ class ExportImport(object):
                 cp(f, blob_file, blob_len)
                 blob_file.close()
             else:
-                f.seek(-len(blob_begin_marker),1)
                 blob_filename = None
 
             pfile = BytesIO(data)

--- a/src/ZODB/ExportImport.py
+++ b/src/ZODB/ExportImport.py
@@ -31,7 +31,7 @@ logger = logging.getLogger('ZODB.ExportImport')
 
 class ExportImport(object):
 
-    def exportFile(self, oid, f=None):
+    def exportFile(self, oid, f=None, bufsize=1 << 16):
         if f is None:
             f = TemporaryFile(prefix="EXP")
         elif isinstance(f, six.string_types):
@@ -64,7 +64,7 @@ class ExportImport(object):
                     f.write(blob_begin_marker)
                     f.write(p64(os.stat(blobfilename).st_size))
                     blobdata = open(blobfilename, "rb")
-                    cp(blobdata, f)
+                    cp(blobdata, f, bufsize=bufsize)
                     blobdata.close()
 
         f.write(export_end_marker)
@@ -170,7 +170,7 @@ class ExportImport(object):
                 # Copy the blob data to a temporary file
                 # and remember the name
                 blob_len = u64(f.read(8))
-                blob_filename = mktemp()
+                blob_filename = mktemp(self._storage.temporaryDirectory())
                 blob_file = open(blob_filename, "wb")
                 cp(f, blob_file, blob_len)
                 blob_file.close()

--- a/src/ZODB/ExportImport.py
+++ b/src/ZODB/ExportImport.py
@@ -31,7 +31,7 @@ logger = logging.getLogger('ZODB.ExportImport')
 
 class ExportImport(object):
 
-    def exportFile(self, oid, f=None, bufsize=1 << 16):
+    def exportFile(self, oid, f=None, bufsize=64 * 1024):
         if f is None:
             f = TemporaryFile(prefix="EXP")
         elif isinstance(f, six.string_types):
@@ -158,7 +158,7 @@ class ExportImport(object):
                 oids[ooid] = oid = self._storage.new_oid()
                 return_oid_list.append(oid)
 
-            if (len(data) < 99 and b'blob' in data and
+            if (b'blob' in data and
                 isinstance(self._reader.getGhost(data), Blob)
                 ):
                 # Blob support

--- a/src/ZODB/ExportImport.py
+++ b/src/ZODB/ExportImport.py
@@ -158,7 +158,7 @@ class ExportImport(object):
                 oids[ooid] = oid = self._storage.new_oid()
                 return_oid_list.append(oid)
 
-            if (len(data) < 99 and 'blob' in data and
+            if (len(data) < 99 and b'blob' in data and
                 isinstance(self._reader.getGhost(data), Blob)
                 ):
                 # Blob support

--- a/src/ZODB/utils.py
+++ b/src/ZODB/utils.py
@@ -95,7 +95,7 @@ def u64(v):
 U64 = u64
 
 
-def cp(f1, f2, length=None):
+def cp(f1, f2, length=None, bufsize=1 << 16):
     """Copy all data from one file to another.
 
     It copies the data from the current position of the input file (f1)
@@ -106,7 +106,7 @@ def cp(f1, f2, length=None):
     """
     read = f1.read
     write = f2.write
-    n = 8192
+    n = bufsize
 
     if length is None:
         old_pos = f1.tell()

--- a/src/ZODB/utils.py
+++ b/src/ZODB/utils.py
@@ -95,7 +95,7 @@ def u64(v):
 U64 = u64
 
 
-def cp(f1, f2, length=None, bufsize=1 << 16):
+def cp(f1, f2, length=None, bufsize=64 * 1024):
     """Copy all data from one file to another.
 
     It copies the data from the current position of the input file (f1)


### PR DESCRIPTION
I'm working on a project where I need to copy object trees that contain many (10s of thousands) of large blobs.  The easiest way to do this (for my application so far) is to leverage export/import.  I wanted to avoid extra file I/O, so I tried exporting to and importing from a pipe.  This failed because import looks for blob markers and then seeks back when they're not found, which is most of the time.  The blob marker (and associated seek) wasn't necessary because the blob object record can serve as a marker.

The primary change in this PR is to leverage blob object records as blob data markers, thus avoiding seeks and permitting pipes to be used.  For backward compatibility, blob-data markers are still written on output and read and checked on input.

In addition to allowing pipes to be used, avoiding seeks should improve performance, because seeks cause file buffers to be discarded.

This PR also provides 2 ancillary blob-related performance improvements:

- When writing blob data during import, temporary files are written to the storage's blob temporary directory, assuring that we don't have to make extra copies.

- The default buffer size for ZODB.utils.cp was increased to (still modest) 64K and made overridable.  Export was updated to allow a larger buffer size to be passed in. (There was no obvious way to make the import buffer size overridable, due to the way things get called.) 