### PR TITLE
Fix typo in doctest documentation of find_global method

### DIFF
--- a/src/ZODB/broken.py
+++ b/src/ZODB/broken.py
@@ -174,7 +174,7 @@ def find_global(modulename, globalname,
          >>> find_global('ZODB.not.there', 'atall') is ZODBnotthere.atall
          True
 
-       Of course, if we beak it again::
+       Of course, if we break it again::
 
          >>> del sys.modules['ZODB.not']
          >>> del sys.modules['ZODB.not.there']


### PR DESCRIPTION
I have seen a little typo in doctest comments and I fixed it. King regards.