### PR TITLE
Save object ids as zodbpickle.binary and use pickle protocol 3 for Python 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,19 @@
 5.4.0 (unreleased)
 ==================
 
+- ZODB now uses pickle protocol 3 for both Python 2 and Python 3.
+
+  (Previously, protocol 2 was used for Python 2.)
+
+  The zodbpickle package provides a `zodbpickle.binary` string type
+  that should be used in Python 2 to cause binary strings to be saved
+  in a pickle binary format, so they can be loaded correctly in
+  Python 3.  Pickle protocol 3 is needed for this to work correctly.
+
+- Object identifiers in persistent references are saved as
+  `zodbpickle.binary` strings in Python 2, so that they are loaded
+  correctly in Python 3.
+
 - If an object is missing from the index while packing a ``FileStorage``,
   report its full ``oid``.
 

--- a/src/ZODB/_compat.py
+++ b/src/ZODB/_compat.py
@@ -16,6 +16,8 @@ from six import PY3
 
 IS_JYTHON = sys.platform.startswith('java')
 
+_protocol = 3
+from zodbpickle import binary
 
 if not PY3:
     # Python 2.x
@@ -34,7 +36,6 @@ if not PY3:
     HIGHEST_PROTOCOL = cPickle.HIGHEST_PROTOCOL
     IMPORT_MAPPING = {}
     NAME_MAPPING = {}
-    _protocol = 2
     FILESTORAGE_MAGIC = b"FS21"
 else:
     # Python 3.x: can't use stdlib's pickle because
@@ -69,7 +70,6 @@ else:
 
     def loads(s):
         return zodbpickle.pickle.loads(s, encoding='ASCII', errors='bytes')
-    _protocol = 3
     FILESTORAGE_MAGIC = b"FS30"
 
 


### PR DESCRIPTION
Fixes #193 