### PR TITLE
Bump dependency on zodbpickle to at least 1.0.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 5.4.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Bump the dependency on zodbpickle to at least 1.0.1. This is
+  required to avoid a memory leak on Python 2.7. See `issue 203
+  <https://github.com/zopefoundation/ZODB/issues/203>`_.
 
 
 5.4.0 (2018-03-26)

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ setup(
         'six',
         'zc.lockfile',
         'zope.interface',
-        'zodbpickle >= 0.6.0',
+        'zodbpickle >= 1.0.1',
     ],
     zip_safe=False,
     entry_points="""


### PR DESCRIPTION
This is required to avoid a memory leak on Python 2.7.

See #203.