### PR TITLE
Add Python 3.7 support. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
           python: 3.5
         - os: linux
           python: 3.6
+        - python: 3.7
+          dist: xenial
+          sudo: true
 install:
     - pip install -U pip
     - pip install -U setuptools zc.buildout

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@
 
 - Bump the dependency on persistent to at least 4.4.0.
 
+- Add support for Python 3.7.
+
 5.4.0 (2018-03-26)
 ==================
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,8 @@ environment:
     - python: 35-x64
     - python: 36
     - python: 36-x64
+    - python: 37
+    - python: 37-x64
 
 install:
   - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ Programming Language :: Python :: 3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
+Programming Language :: Python :: 3.7
 Programming Language :: Python :: Implementation :: CPython
 Programming Language :: Python :: Implementation :: PyPy
 Topic :: Database

--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -1328,7 +1328,7 @@ class TransactionMetaData(object):
     @property
     def _extension(self):
         warnings.warn("_extension is deprecated, use extension",
-                      DeprecationWarning)
+                      DeprecationWarning, stacklevel=2)
         return self.extension
 
     @_extension.setter

--- a/src/ZODB/scripts/tests/test_doc.py
+++ b/src/ZODB/scripts/tests/test_doc.py
@@ -19,7 +19,7 @@ import zope.testing.renormalizing
 
 checker = zope.testing.renormalizing.RENormalizing([
     (re.compile(
-        '[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+'),
+        r'[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+'),
      '2007-11-10 15:18:48.543001'),
     (re.compile('hash=[0-9a-f]{40}'),
      'hash=b16422d09fabdb45d4e4325e4b42d7d6f021d3c3'),
@@ -29,13 +29,13 @@ checker = zope.testing.renormalizing.RENormalizing([
     # Python 3 produces larger pickles, even when we use zodbpickle :(
     # this changes all the offsets and sizes in fstail.txt
     (re.compile("user='' description='' "
-                    "length=[0-9]+ offset=[0-9]+ \(\+23\)"),
-                "user='' description='' "
-                    "length=<LENGTH> offset=<OFFSET> (+23)"),
+                r"length=[0-9]+ offset=[0-9]+ \(\+23\)"),
+     "user='' description='' "
+     "length=<LENGTH> offset=<OFFSET> (+23)"),
     (re.compile("user='' description='initial database creation' "
-                    "length=[0-9]+ offset=4 \(\+48\)"),
-                "user='' description='initial database creation' "
-                    "length=<LENGTH> offset=4 (+48)"),
+                r"length=[0-9]+ offset=4 \(\+48\)"),
+     "user='' description='initial database creation' "
+     "length=<LENGTH> offset=4 (+48)"),
 ])
 
 def test_suite():

--- a/src/ZODB/tests/testConnection.py
+++ b/src/ZODB/tests/testConnection.py
@@ -36,7 +36,7 @@ checker = renormalizing.RENormalizing([
     # Python 3 bytes add a "b".
     (re.compile("b('.*?')"), r"\1"),
     # Python 3 removes empty list representation.
-    (re.compile("set\(\[\]\)"), r"set()"),
+    (re.compile(r"set\(\[\]\)"), r"set()"),
     # Python 3 adds module name to exceptions.
     (re.compile("ZODB.POSException.POSKeyError"), r"POSKeyError"),
     (re.compile("ZODB.POSException.ReadConflictError"), r"ReadConflictError"),
@@ -198,7 +198,7 @@ class SetstateErrorLoggingTests(ZODB.tests.util.TestCase):
             record.msg,
             "Shouldn't load state for ZODB.tests.testConnection.StubObject"
             " 0x01 when the connection is closed")
-        self.assert_(record.exc_info)
+        self.assertTrue(record.exc_info)
 
 
 class UserMethodTests(unittest.TestCase):

--- a/src/ZODB/tests/test_TransactionMetaData.py
+++ b/src/ZODB/tests/test_TransactionMetaData.py
@@ -38,31 +38,37 @@ class TransactionMetaDataTests(unittest.TestCase):
         self.assertEqual(t.user, b'user')
         self.assertEqual(t.description, b'description')
         self.assertEqual(t.extension, dict(foo='FOO'))
-        self.assertEqual(t._extension, t.extension)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.assertEqual(t._extension, t.extension)
 
     def test_constructor_default_args(self):
         t = TransactionMetaData()
         self.assertEqual(t.user, b'')
         self.assertEqual(t.description, b'')
         self.assertEqual(t.extension, {})
-        self.assertEqual(t._extension, t.extension)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.assertEqual(t._extension, t.extension)
 
     def test_set_extension(self):
         t = TransactionMetaData(u'', u'', b'')
         self.assertEqual(t.user, b'')
         self.assertEqual(t.description, b'')
         self.assertEqual(t.extension, {})
-        self.assertEqual(t._extension, t.extension)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.assertEqual(t._extension, t.extension)
 
-        for name in 'extension', '_extension':
-            data = {name: name + 'foo'}
-            setattr(t, name, data)
-            self.assertEqual(t.extension, data)
-            self.assertEqual(t._extension, t.extension)
-            data = {}
-            setattr(t, name, data)
-            self.assertEqual(t.extension, data)
-            self.assertEqual(t._extension, t.extension)
+            for name in 'extension', '_extension':
+                data = {name: name + 'foo'}
+                setattr(t, name, data)
+                self.assertEqual(t.extension, data)
+                self.assertEqual(t._extension, t.extension)
+                data = {}
+                setattr(t, name, data)
+                self.assertEqual(t.extension, data)
+                self.assertEqual(t._extension, t.extension)
 
     def test_used_by_connection(self):
         import ZODB
@@ -109,4 +115,3 @@ def test_suite():
 
 if __name__ == '__main__':
     unittest.main(defaultTest='test_suite')
-

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # Jython 2.7rc2 does work, but unfortunately has an issue running
 # with Tox 1.9.2 (http://bugs.jython.org/issue2325)
 #envlist = py26,py27,py33,py34,pypy,simple,jython,pypy3
-envlist = py27,py34,py35,py36,pypy,pypy3
+envlist = py27,py34,py35,py36,py37,pypy,pypy3
 
 [testenv]
 # ZODB.tests.testdocumentation needs to find
@@ -16,7 +16,7 @@ commands =
 # Run unit tests first.
     zope-testrunner -u --test-path=src []
 # Only run functional tests if unit tests pass.
-    zope-testrunner -f --test-path=src []
+    zope-testrunner -f -j5 --test-path=src []
 deps =
     .[test]
 


### PR DESCRIPTION
And fix all the deprecations it reports.

Fixes #214 and fixes #215 (well there's one remaining deprecation in 'manuel')

Based on #217 so that all tests pass.