### PR TITLE
Avoid most calls to time.sleep() in the tests by mocking time.[gm]time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ install:
     - pip install -U setuptools zc.buildout
     - buildout $BUILOUT_OPTIONS
 script:
-    - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then bin/coverage run bin/coverage-test -v1j99; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then bin/test -v1j99; fi
+    - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then bin/coverage run bin/coverage-test -v; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then bin/test -v; fi
     - if [[ $TRAVIS_PYTHON_VERSION != pypy3* ]]; then make -C doc html; fi
     - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then pip install coveralls; fi # install early enough to get into the cache
 after_success:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@
   exceptions on certain types of bad input. See `issue 216
   <https://github.com/zopefoundation/ZODB/issues/216>`_.
 
+- Make the tests run faster by avoiding calls to ``time.sleep()``.
+
 5.4.0 (2018-03-26)
 ==================
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,10 @@ environment:
 install:
   - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
   - echo "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 > "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"
-  - pip install -e .
-  - pip install zope.testrunner zope.testing manuel
-  - pip install zc.buildout zc.recipe.testrunner zc.recipe.egg
+  - python -m pip install -U pip setuptools wheel
+  - pip install -U -e .
+  - pip install -U zope.testrunner zope.testing manuel
+  - pip install -U zc.buildout zc.recipe.testrunner zc.recipe.egg
 
 build_script:
   - buildout bootstrap

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ long_description = read("README.rst") + "\n\n" + read("CHANGES.rst")
 
 tests_require = [
     'manuel',
+    'mock; python_version == "2.7"',
     'zope.testing',
     'zope.testrunner >= 4.4.6',
 ]

--- a/src/ZODB/tests/PackableStorage.py
+++ b/src/ZODB/tests/PackableStorage.py
@@ -30,6 +30,7 @@ from ZODB._compat import (loads, PersistentPickler, Pickler, Unpickler,
 import transaction
 import ZODB.interfaces
 import ZODB.tests.util
+from ZODB.tests.util import time_monotonically_increases
 import zope.testing.setupstack
 
 from ZODB.utils import load_current
@@ -274,12 +275,15 @@ class PackableStorage(PackableStorageBase):
 
         db.close()
 
+    @time_monotonically_increases
     def checkPackWhileWriting(self):
         self._PackWhileWriting(pack_now=False)
 
+    @time_monotonically_increases
     def checkPackNowWhileWriting(self):
         self._PackWhileWriting(pack_now=True)
 
+    @time_monotonically_increases
     def checkPackLotsWhileWriting(self):
         # This is like the other pack-while-writing tests, except it packs
         # repeatedly until the client thread is done.  At the time it was
@@ -608,6 +612,7 @@ class PackableUndoStorage(PackableStorageBase):
 
         eq(root['obj'].value, 7)
 
+    @time_monotonically_increases
     def checkRedundantPack(self):
         # It is an error to perform a pack with a packtime earlier
         # than a previous packtime.  The storage can't do a full
@@ -652,6 +657,7 @@ class PackableUndoStorage(PackableStorageBase):
         # it is reachable.
         load_current(self._storage, lost_oid)
 
+    @time_monotonically_increases(0.1)
     def checkPackUndoLog(self):
         self._initroot()
         # Create a `persistent' object
@@ -669,7 +675,7 @@ class PackableUndoStorage(PackableStorageBase):
         self.assertEqual(3, len(self._storage.undoLog()))
         self._storage.pack(packtime, referencesf)
         # The undo log contains only the most resent transaction
-        self.assertEqual(1,len(self._storage.undoLog()))
+        self.assertEqual(1, len(self._storage.undoLog()))
 
     def dont_checkPackUndoLogUndoable(self):
         # A disabled test. I wanted to test that the content of the

--- a/src/ZODB/tests/RecoveryStorage.py
+++ b/src/ZODB/tests/RecoveryStorage.py
@@ -21,6 +21,7 @@ from ZODB import DB
 from ZODB.serialize import referencesf
 
 from ZODB.utils import load_current
+from ZODB.tests.util import time_monotonically_increases
 
 import time
 
@@ -66,6 +67,7 @@ class RecoveryStorage(IteratorDeepCompare):
         self._dst.tpc_vote(final)
         self._dst.tpc_finish(final)
 
+    @time_monotonically_increases
     def checkPackWithGCOnDestinationAfterRestore(self):
         raises = self.assertRaises
         db = DB(self._storage)

--- a/src/ZODB/tests/RevisionStorage.py
+++ b/src/ZODB/tests/RevisionStorage.py
@@ -17,6 +17,7 @@ from ZODB.Connection import TransactionMetaData
 from ZODB.tests.MinPO import MinPO
 from ZODB.tests.StorageTestBase import zodb_unpickle, zodb_pickle, snooze
 from ZODB.utils import p64, u64, load_current
+from ZODB.tests.util import time_monotonically_increases
 
 ZERO = '\0'*8
 
@@ -34,6 +35,7 @@ class RevisionStorage(object):
             data = self._storage.loadSerial(oid, revid)
             self.assertEqual(zodb_unpickle(data), value)
 
+    @time_monotonically_increases
     def checkLoadBefore(self):
         # Store 10 revisions of one object and then make sure that we
         # can get all the non-current revisions back.
@@ -89,6 +91,7 @@ class RevisionStorage(object):
         self.assertEqual(start, revid1)
         self.assertEqual(end, revid2)
 
+    @time_monotonically_increases
     def checkLoadBeforeOld(self):
         # Look for a very old revision.  With the BaseStorage implementation
         # this should require multple history() calls.

--- a/src/ZODB/tests/testCache.py
+++ b/src/ZODB/tests/testCache.py
@@ -378,7 +378,12 @@ class CacheErrors(unittest.TestCase):
             # structure that adds a new reference to None for each executed
             # line of code, which interferes with this test.  So check it
             # only if we're running without coverage tracing.
-            self.assertEqual(rc(None), nones)
+
+            # On Python 3.7, we can see the value of reference counts
+            # to None actually go *down* by a few. Possibly it has to
+            # do with the lazy tracking of frames?
+            # (https://github.com/python/cpython/commit/5a625d0aa6a6d9ec6574ee8344b41d63dcb9897e)
+            self.assertLessEqual(rc(None), nones)
 
     def testTwoCaches(self):
         jar2 = StubDataManager()

--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,7 @@ envlist = py27,py34,py35,py36,py37,pypy,pypy3
 # out of the tox site-packages.
 usedevelop = true
 commands =
-# Run unit tests first.
-    zope-testrunner -u --test-path=src []
-# Only run functional tests if unit tests pass.
-    zope-testrunner -f -j5 --test-path=src []
+    zope-testrunner --test-path=src []
 deps =
     .[test]
 


### PR DESCRIPTION
This also makes us more deterministic. (Based on [code I wrote for nti.testing](https://github.com/NextThought/nti.testing/blob/master/src/nti/testing/time.py).)

On my machine, this speeds up a sequential test run from 4:08 to 1:30. An AppVeyor 2.7, where we run tests sequentially, the time went from over five minutes to 2:35.

We no longer get much benefit from running the layer tests in parallel on CI, in fact it looks like the overhead actually slows them down slightly, so stop doing that.

This obsoletes the hack we have for running coverage in parallel on CI; I plan a followup PR to remove that (if this is accepted). 

The tests fail on appveyor 3.4 because its version of setuptools is so old. I would like to also address that in the same PR that adjusts the coverage hacks on Travis. (EDIT: Addressed when I added the lock.)