### PR TITLE
Repozo : add an option to verify on recovery

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 5.5.2 (unreleased)
 ==================
 
+- Make repozo's recover mode atomic by recovering the backup in a
+  temporary file which is then moved to the expected output file.
 - Add a new option to repozo in recover mode which allows to verify
   backups integrity on the fly.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 5.5.2 (unreleased)
 ==================
 
-- TBD
+- Add a new option to repozo in recover mode which allows to verify
+  backups integrity on the fly.
 
 5.5.1 (2018-10-25)
 ==================

--- a/src/ZODB/scripts/repozo.py
+++ b/src/ZODB/scripts/repozo.py
@@ -360,8 +360,6 @@ def concat(files, ofp=None):
             ifp = open(f, 'rb')
         bytesread += dofile(func, ifp)
         ifp.close()
-    if ofp:
-        ofp.close()
     return bytesread, sum.hexdigest()
 
 

--- a/src/ZODB/scripts/repozo.py
+++ b/src/ZODB/scripts/repozo.py
@@ -108,15 +108,21 @@ READCHUNK = 16 * 1024
 VERBOSE = False
 
 
-class WouldOverwriteFiles(Exception):
+class RepozoError(Exception):
     pass
 
 
-class NoFiles(Exception):
+class WouldOverwriteFiles(RepozoError):
     pass
 
-class VerificationFail(Exception):
+
+class NoFiles(RepozoError):
     pass
+
+
+class VerificationFail(RepozoError):
+    pass
+
 
 class _GzipCloser(object):
 
@@ -785,24 +791,16 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
     options = parseargs(argv)
-    if options.mode == BACKUP:
-        try:
+    try:
+        if options.mode == BACKUP:
             do_backup(options)
-        except WouldOverwriteFiles as e:
-            sys.exit(str(e))
-        except VerificationFail as e:
-            sys.exit(str(e))
-    elif options.mode == RECOVER:
-        try:
+        elif options.mode == RECOVER:
             do_recover(options)
-        except NoFiles as e:
-            sys.exit(str(e))
-    else:
-        assert options.mode == VERIFY
-        try:
+        else:
+            assert options.mode == VERIFY
             do_verify(options)
-        except NoFiles as e:
-            sys.exit(str(e))
+    except (RepozoError, OSError) as e:
+        sys.exit(str(e))
 
 
 if __name__ == '__main__':

--- a/src/ZODB/scripts/tests/test_repozo.py
+++ b/src/ZODB/scripts/tests/test_repozo.py
@@ -936,6 +936,7 @@ class Test_do_recover(OptionsTestBase, unittest.TestCase):
            '/backup/2010-05-14-02-03-04.fs 0 3 e1faffb3e614e6c2fba74296962386b7\n'
            '/backup/2010-05-14-04-05-06.deltafs 3 7 f50881ced34c7d9e6bce100bf33dec60\n')
         self._callFUT(options)
+        self.assertFalse(os.path.exists(output + '.part'))
         self.assertEqual(_read_file(output), b'AAABBBB')
 
     def test_w_incr_backup_with_verify_sum_inconsistent(self):
@@ -953,6 +954,7 @@ class Test_do_recover(OptionsTestBase, unittest.TestCase):
            '/backup/2010-05-14-02-03-04.fs 0 3 e1faffb3e614e6c2fba74296962386b7\n'
            '/backup/2010-05-14-04-05-06.deltafs 3 7 f50881ced34c7d9e6bce100bf33dec61\n')
         self.assertRaises(VerificationFail, self._callFUT, options)
+        self.assertTrue(os.path.exists(output + '.part'))
 
     def test_w_incr_backup_with_verify_size_inconsistent(self):
         import tempfile
@@ -969,6 +971,7 @@ class Test_do_recover(OptionsTestBase, unittest.TestCase):
            '/backup/2010-05-14-02-03-04.fs 0 3 e1faffb3e614e6c2fba74296962386b7\n'
            '/backup/2010-05-14-04-05-06.deltafs 3 8 f50881ced34c7d9e6bce100bf33dec60\n')
         self.assertRaises(VerificationFail, self._callFUT, options)
+        self.assertTrue(os.path.exists(output + '.part'))
 
 
 class Test_do_verify(OptionsTestBase, unittest.TestCase):

--- a/src/ZODB/scripts/tests/test_repozo.py
+++ b/src/ZODB/scripts/tests/test_repozo.py
@@ -414,7 +414,7 @@ class Test_concat(OptionsTestBase, unittest.TestCase):
         ofp = Faux()
         bytes, sum = self._callFUT(files, ofp)
         self.assertEqual(ofp._written, [x.encode() for x in 'ABC'])
-        self.assertTrue(ofp._closed)
+        self.assertFalse(ofp._closed)
 
 _marker = object()
 class Test_gen_filename(OptionsTestBase, unittest.TestCase):

--- a/src/ZODB/scripts/tests/test_repozo.py
+++ b/src/ZODB/scripts/tests/test_repozo.py
@@ -371,7 +371,7 @@ class Test_concat(OptionsTestBase, unittest.TestCase):
         from ZODB.scripts.repozo import _GzipCloser
         import tempfile
         if self._repository_directory is None:
-            self._repository_directory = tempfile.mkdtemp()
+            self._repository_directory = tempfile.mkdtemp(prefix='zodb-test-')
         fqn = os.path.join(self._repository_directory, name)
         if gzip_file:
             _opener = _GzipCloser
@@ -674,7 +674,7 @@ class Test_do_full_backup(OptionsTestBase, unittest.TestCase):
 
     def _makeDB(self):
         import tempfile
-        datadir = self._data_directory = tempfile.mkdtemp()
+        datadir = self._data_directory = tempfile.mkdtemp(prefix='zodb-test-')
         return OurDB(self._data_directory)
 
     def test_dont_overwrite_existing_file(self):
@@ -729,7 +729,7 @@ class Test_do_incremental_backup(OptionsTestBase, unittest.TestCase):
 
     def _makeDB(self):
         import tempfile
-        datadir = self._data_directory = tempfile.mkdtemp()
+        datadir = self._data_directory = tempfile.mkdtemp(prefix='zodb-test-')
         return OurDB(self._data_directory)
 
     def test_dont_overwrite_existing_file(self):
@@ -868,7 +868,7 @@ class Test_do_recover(OptionsTestBase, unittest.TestCase):
 
     def test_w_full_backup_latest_no_index(self):
         import tempfile
-        dd = self._data_directory = tempfile.mkdtemp()
+        dd = self._data_directory = tempfile.mkdtemp(prefix='zodb-test-')
         output = os.path.join(dd, 'Data.fs')
         index = os.path.join(dd, 'Data.fs.index')
         options = self._makeOptions(date='2010-05-15-13-30-57',
@@ -881,7 +881,7 @@ class Test_do_recover(OptionsTestBase, unittest.TestCase):
 
     def test_w_full_backup_latest_index(self):
         import tempfile
-        dd = self._data_directory = tempfile.mkdtemp()
+        dd = self._data_directory = tempfile.mkdtemp(prefix='zodb-test-')
         output = os.path.join(dd, 'Data.fs')
         index = os.path.join(dd, 'Data.fs.index')
         options = self._makeOptions(date='2010-05-15-13-30-57',
@@ -896,7 +896,7 @@ class Test_do_recover(OptionsTestBase, unittest.TestCase):
 
     def test_w_incr_backup_latest_no_index(self):
         import tempfile
-        dd = self._data_directory = tempfile.mkdtemp()
+        dd = self._data_directory = tempfile.mkdtemp(prefix='zodb-test-')
         output = os.path.join(dd, 'Data.fs')
         index = os.path.join(dd, 'Data.fs.index')
         options = self._makeOptions(date='2010-05-15-13-30-57',
@@ -909,7 +909,7 @@ class Test_do_recover(OptionsTestBase, unittest.TestCase):
 
     def test_w_incr_backup_latest_index(self):
         import tempfile
-        dd = self._data_directory = tempfile.mkdtemp()
+        dd = self._data_directory = tempfile.mkdtemp(prefix='zodb-test-')
         output = os.path.join(dd, 'Data.fs')
         index = os.path.join(dd, 'Data.fs.index')
         options = self._makeOptions(date='2010-05-15-13-30-57',
@@ -924,7 +924,7 @@ class Test_do_recover(OptionsTestBase, unittest.TestCase):
 
     def test_w_incr_backup_with_verify_all_is_fine(self):
         import tempfile
-        dd = self._data_directory = tempfile.mkdtemp()
+        dd = self._data_directory = tempfile.mkdtemp(prefix='zodb-test-')
         output = os.path.join(dd, 'Data.fs')
         index = os.path.join(dd, 'Data.fs.index')
         options = self._makeOptions(date='2010-05-15-13-30-57',
@@ -941,7 +941,7 @@ class Test_do_recover(OptionsTestBase, unittest.TestCase):
     def test_w_incr_backup_with_verify_sum_inconsistent(self):
         import tempfile
         from ZODB.scripts.repozo import VerificationFail
-        dd = self._data_directory = tempfile.mkdtemp()
+        dd = self._data_directory = tempfile.mkdtemp(prefix='zodb-test-')
         output = os.path.join(dd, 'Data.fs')
         index = os.path.join(dd, 'Data.fs.index')
         options = self._makeOptions(date='2010-05-15-13-30-57',
@@ -957,7 +957,7 @@ class Test_do_recover(OptionsTestBase, unittest.TestCase):
     def test_w_incr_backup_with_verify_size_inconsistent(self):
         import tempfile
         from ZODB.scripts.repozo import VerificationFail
-        dd = self._data_directory = tempfile.mkdtemp()
+        dd = self._data_directory = tempfile.mkdtemp(prefix='zodb-test-')
         output = os.path.join(dd, 'Data.fs')
         index = os.path.join(dd, 'Data.fs.index')
         options = self._makeOptions(date='2010-05-15-13-30-57',
@@ -1121,7 +1121,7 @@ class MonteCarloTests(unittest.TestCase):
     def setUp(self):
         # compute directory names
         import tempfile
-        self.basedir = tempfile.mkdtemp()
+        self.basedir = tempfile.mkdtemp(prefix='zodb-test-')
         self.backupdir = os.path.join(self.basedir, 'backup')
         self.datadir = os.path.join(self.basedir, 'data')
         self.restoredir = os.path.join(self.basedir, 'restore')


### PR DESCRIPTION
This PR aims to reduce the number of IO operations when recovering a ZODB backup with repozo, when user wants to also verify the data. The idea is to add a new option for the -R/--recovery mode which will run the same checks as the -v/--Verify mode, but by reading data in increment files only once.

Also, I did a first commit to prevent the concat() function to close the file descriptor, as currently it is closed twice : once in concat(), and once in the function calling concat(). I think it should be the responsability of the one opening the file to also close it. What surprised me is that there was an assertion in tests checking that concat() was indeed closing the file descriptor. I couldn't find in the git history the explanation why.