### PR TITLE
Tests: Always pass bytes for the previous serial param of storage.store

### DIFF
--- a/src/ZODB/interfaces.py
+++ b/src/ZODB/interfaces.py
@@ -774,43 +774,30 @@ class IStorage(Interface):
     def store(oid, serial, data, version, transaction):
         """Store data for the object id, oid.
 
-        Arguments:
+        :param bytes oid: The object identifier. This is either a
+            string consisting of 8 nulls or a string previously
+            returned by new_oid.
+        :param bytes serial: The serial of the data that was read when
+            the object was loaded from the database. If the object was
+            created in the current transaction this will be a string
+            consisting of 8 nulls.
+        :param bytes data: The data record. This is opaque to the
+            storage.
+        :param version: This must be an empty string. It exists for
+            backward compatibility.
+        :param transaction: The object passed to tpc_begin
 
-        oid
-            The object identifier.  This is either a string
-            consisting of 8 nulls or a string previously returned by
-            new_oid.
+        :raises ConflictError: Raised when serial does not match the
+            most recent serial number for object oid and the conflict
+            was not resolved by the storage. Note that this may be deferred
+            to :meth:`tpc_vote`.
 
-        serial
-            The serial of the data that was read when the object was
-            loaded from the database.  If the object was created in
-            the current transaction this will be a string consisting
-            of 8 nulls.
+        :raises StorageTransactionError: Raised when transaction does
+            not match the current transaction.
 
-        data
-            The data record. This is opaque to the storage.
-
-        version
-            This must be an empty string. It exists for backward compatibility.
-
-        transaction
-            The object passed to tpc_begin
-
-        Several different exceptions may be raised when an error occurs.
-
-        ConflictError
-          is raised when serial does not match the most recent serial
-          number for object oid and the conflict was not resolved by
-          the storage.
-
-        StorageTransactionError
-          is raised when transaction does not match the current
-          transaction.
-
-        StorageError or, more often, a subclass of it
-          is raised when an internal error occurs while the storage is
-          handling the store() call.
-
+        :raises StorageError: Raised when an internal error occurs
+            while the storage is handling the store() call. Most often this
+            is a descriptive subclass.
         """
 
     def tpc_abort(transaction):

--- a/src/ZODB/scripts/migrate.py
+++ b/src/ZODB/scripts/migrate.py
@@ -80,12 +80,12 @@ import getopt
 import marshal
 import profile
 
+from persistent.timestamp import TimeStamp
 from ZODB import utils
-from ZODB import StorageTypes
-from ZODB.TimeStamp import TimeStamp
+from ZODB import StorageTypes # XXX: This import does not exist
+
 
 PROGRAM = sys.argv[0]
-ZERO = '\0'*8
 
 
 def usage(code, msg=''):
@@ -283,7 +283,7 @@ def doit(srcdb, dstdb, options):
                 else:
                     vstr = r.version
                 print(utils.U64(oid), vstr, len(r.data))
-            oldrevid = prevrevids.get(oid, ZERO)
+            oldrevid = prevrevids.get(oid, utils.z64)
             result = dstdb.store(oid, oldrevid, r.data, r.version, txn)
             newrevids.store(oid, result)
         t2 = time.time()

--- a/src/ZODB/tests/BasicStorage.py
+++ b/src/ZODB/tests/BasicStorage.py
@@ -22,6 +22,7 @@ from ZODB import POSException
 from ZODB.Connection import TransactionMetaData
 from ZODB.tests.MinPO import MinPO
 from ZODB.tests.StorageTestBase import zodb_unpickle, zodb_pickle
+from ZODB.tests.StorageTestBase import ZERO
 
 import threading
 import time
@@ -29,8 +30,6 @@ import zope.interface
 import zope.interface.verify
 
 from .. import utils
-
-ZERO = b'\0'*8
 
 class BasicStorage(object):
     def checkBasics(self):

--- a/src/ZODB/tests/IteratorStorage.py
+++ b/src/ZODB/tests/IteratorStorage.py
@@ -21,6 +21,7 @@ all these tests.
 from ZODB.Connection import TransactionMetaData
 from ZODB.tests.MinPO import MinPO
 from ZODB.tests.StorageTestBase import zodb_pickle, zodb_unpickle
+from ZODB.tests.StorageTestBase import ZERO
 from ZODB.utils import U64, p64, load_current
 
 import ZODB.blob
@@ -126,7 +127,7 @@ class IteratorStorage(IteratorCompare):
         data = zodb_pickle(MinPO(0))
         try:
             self._storage.tpc_begin(t)
-            self._storage.store(oid, '\0'*8, data, '', t)
+            self._storage.store(oid, ZERO, data, '', t)
             self._storage.tpc_vote(t)
             # Don't do tpc_finish yet
             it = self._storage.iterator()

--- a/src/ZODB/tests/RevisionStorage.py
+++ b/src/ZODB/tests/RevisionStorage.py
@@ -16,10 +16,10 @@
 from ZODB.Connection import TransactionMetaData
 from ZODB.tests.MinPO import MinPO
 from ZODB.tests.StorageTestBase import zodb_unpickle, zodb_pickle, snooze
+from ZODB.tests.StorageTestBase import ZERO
 from ZODB.utils import p64, u64, load_current
 from ZODB.tests.util import time_monotonically_increases
 
-ZERO = '\0'*8
 
 class RevisionStorage(object):
 

--- a/src/ZODB/tests/StorageTestBase.py
+++ b/src/ZODB/tests/StorageTestBase.py
@@ -29,7 +29,7 @@ from ZODB._compat import PersistentPickler, Unpickler, BytesIO, _protocol
 import ZODB.tests.util
 
 
-ZERO = b'\0'*8
+ZERO = z64
 
 def snooze():
     # In Windows, it's possible that two successive time.time() calls return

--- a/src/ZODB/tests/TransactionalUndoStorage.py
+++ b/src/ZODB/tests/TransactionalUndoStorage.py
@@ -31,8 +31,8 @@ from ZODB import DB
 
 from ZODB.tests.MinPO import MinPO
 from ZODB.tests.StorageTestBase import zodb_pickle, zodb_unpickle
+from ZODB.tests.StorageTestBase import ZERO
 
-ZERO = '\0'*8
 
 class C(Persistent):
     pass


### PR DESCRIPTION
In a few cases, they were passing native strings, which complicates things on Python 3.

This is consistent with what persistent.Persistent and Connection actually do.

RelStorage previously had a special case just for these tests.