### PR TITLE
Make TmpStore implement its own getSize

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,11 @@
   holds bytes as they are stored (i.e. no deserialization happens).
   See `issue 207 <https://github.com/zopefoundation/ZODB/pull/207>`_.
 
+- Make a connection's savepoint storage implement its own
+  (approximate) ``getSize`` method instead of relying on the original
+  storage. Previously, this produced confusing DEBUG logging. See
+  `issue 282 <https://github.com/zopefoundation/ZODB/issues/282>`_.
+
 5.5.1 (2018-10-25)
 ==================
 

--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -1135,20 +1135,22 @@ class TmpStore(object):
     def __init__(self, storage):
         self._storage = storage
         for method in (
-            'getName', 'new_oid', 'getSize', 'sortKey',
+            'getName', 'new_oid', 'sortKey',
             'isReadOnly'
             ):
             setattr(self, method, getattr(storage, method))
 
         self._file = tempfile.TemporaryFile(prefix='TmpStore')
-        # position: current file position
-        # _tpos: file position at last commit point
+        # position: current file position. If objects are only stored
+        # once, this is approximately the byte size of object data stored.
         self.position = 0
         # index: map oid to pos of last committed version
         self.index = {}
         self.creating = {}
-
         self._blob_dir = None
+
+    def getSize(self):
+        return self.position
 
     def __len__(self):
         return len(self.index)


### PR DESCRIPTION
This is more consistent with its ``__len__`` (thanks @jmuchemb for pointing that out) and provides a better figure for existing logging. It's still approximate, but less wildly wrong than before.

Fixes #282