### PR TITLE
Simplify appveyor.yml.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,5 +17,9 @@ install:
   - python -m pip install -U pip setuptools wheel
   - pip install -U -e .[test]
 
+build_script:
+  - python -m pip install -U wheel
+  - python -W ignore setup.py -q bdist_wheel
+
 test_script:
   - zope-testrunner --test-path=src -vvv --auto-color

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,13 +15,7 @@ install:
   - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
   - echo "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 > "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"
   - python -m pip install -U pip setuptools wheel
-  - pip install -U -e .
-  - pip install -U zope.testrunner zope.testing manuel
-  - pip install -U zc.buildout zc.recipe.testrunner zc.recipe.egg
-
-build_script:
-  - buildout bootstrap
-  - bin\buildout parts=test
+  - pip install -U -e .[test]
 
 test_script:
-  - bin\test -vvv
+  - zope-testrunner --test-path=src -vvv --auto-color


### PR DESCRIPTION
Fixes issues with zc.buildout and version pins (https://github.com/zopefoundation/ZODB/pull/295#issuecomment-593805066)

(Hopefully. Still waiting for the CI to run.)