### PR TITLE
Update package links from pypi.python.org to pypi.org

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -238,7 +238,7 @@ New Features
 
 - The mkzeoinst script has been moved to a separate project:
 
-    http://pypi.python.org/pypi/zope.mkzeoinstance
+    https://pypi.org/project/zope.mkzeoinstance/
 
   and is no-longer included with ZODB.
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ ZODB, a Python object-oriented database
 =======================================
 
 .. image:: https://img.shields.io/pypi/v/ZODB.svg
-   :target: https://pypi.python.org/pypi/ZODB/
+   :target: https://pypi.org/project/ZODB/
    :alt: Latest release
 
 .. image:: https://img.shields.io/pypi/pyversions/ZODB.svg

--- a/doc/articles/ZODB-overview.rst
+++ b/doc/articles/ZODB-overview.rst
@@ -56,15 +56,15 @@ ordering.
 The hot points for ConflictErrors are the catalogue indexes. Some of the
 indexes do not support conflict resolution and you will see ConflictErrors
 under write-intensive loads. On solution is to defer catalogue updates using
-`QueueCatalog <http://pypi.python.org/pypi/Products.QueueCatalog>`_
+`QueueCatalog <https://pypi.org/project/Products.QueueCatalog/>`_
 (`PloneQueueCatalog
-<http://pypi.python.org/pypi/Products.PloneQueueCatalog>`_), which allows
+<https://pypi.org/project/Products.PloneQueueCatalog/>`_), which allows
 indexing operations to be serialized using a seperate ZEO client. This can
 bring big performance benefits as request retries are reduced, but the
 downside is that index updates are no longer reflected immediately in the
 application. Another alternative is to offload text indexing to a dedicated
 search engine using `collective.solr
-<http://pypi.python.org/pypi/collective.solr>`_.
+<https://pypi.org/project/collective.solr/>`_.
 
 This brings us to **Atomicity**, the other key feature of ZODB transactions. A
 transaction will either succeed or fail, your data is never left in an
@@ -76,7 +76,7 @@ ConflictError occurs Zope will attempt to replay a transaction up to three
 times. Interactions with an external system should be made through a Data
 Manager that participates in the transaction. If you’re talking to a database
 use a Zope DA or a SQLAlchemy wrapper like `zope.sqlalchemy
-<http://pypi.python.org/pypi/zope.sqlalchemy>`_.
+<https://pypi.org/project/zope.sqlalchemy/>`_.
 
 Unfortunately the default MailHost implementation used by Plone is not
 transaction aware. With it you can see duplicate emails sent. If this is a
@@ -115,7 +115,7 @@ file per object revision. Does not require the Data.fs.index to be rebuilt on
 an unclean shutdown (which can take a significant time for a large database).
 Small number of users.
 
-**RelStorage** (`pypi <http://pypi.python.org/pypi/RelStorage>`_) stores
+**RelStorage** (`pypi <https://pypi.org/project/RelStorage/>`_) stores
 pickles in a relational database. PostgreSQL, MySQL and Oracle are supported
 and no ZEO server is required. You benefit from the faster network layers of
 these database adapters. However, conflict resolution is moved to the

--- a/doc/articles/multi-zodb-gc.rst
+++ b/doc/articles/multi-zodb-gc.rst
@@ -3,7 +3,7 @@ Using zc.zodbdgc (fix PosKeyError's)
 
 *This article was written by Hanno Schlichting*
 
-The `zc.zodbdgc <http://pypi.python.org/pypi/zc.zodbdgc>`_ library contains two
+The `zc.zodbdgc <https://pypi.org/project/zc.zodbdgc/>`_ library contains two
 useful features. On the one hand it supports advanced ZODB packing and garbage
 collection approaches and on the other hand it includes the ability to create a
 database of all persistent references.
@@ -18,7 +18,7 @@ persistent object(s) that point to the lost object.
 
 .. note:: 
     Unless you're using multi-databases, this documentation does not apply to
-    `RelStorage <http://pypi.python.org/pypi/RelStorage>`_ which has the same
+    `RelStorage <https://pypi.org/project/RelStorage/>`_ which has the same
     features built-in, but accessible in different ways. Look at the options for
     the ``zodbpack`` script. The ``--prepack`` option creates a table containing the
     same information as we are creating in the reference database. 

--- a/doc/guide/install-and-run.rst
+++ b/doc/guide/install-and-run.rst
@@ -14,8 +14,8 @@ packaging system. For example, using pip::
   pip install ZODB
 
 You may need additional optional packages, such as `ZEO
-<https://pypi.python.org/pypi/ZEO>`_ or `RelStorage
-<https://pypi.python.org/pypi/RelStorage>`_, depending your deployment
+<https://pypi.org/project/ZEO/>`_ or `RelStorage
+<https://pypi.org/project/RelStorage/>`_, depending your deployment
 choices.
 
 Configuration
@@ -53,7 +53,7 @@ we want to save space, we could layer a ``ZlibStorage``
     compressed_storage = zc.zlibstorage.ZlibStorage(storage)
     db = ZODB.DB(compressed_storage)
 
-`ZlibStorage <https://pypi.python.org/pypi/zc.zlibstorage>`_
+`ZlibStorage <https://pypi.org/project/zc.zlibstorage/>`_
 compresses database records [#zlib]_.
 
 Python configuration
@@ -80,7 +80,7 @@ similar to Apache configuration files.  The syntax was chosen to be
 familiar to site administrators.
 
 ZODB's text configuration uses `ZConfig
-<https://pypi.python.org/pypi/ZConfig>`_. You can use ZConfig to
+<https://pypi.org/project/ZConfig/>`_. You can use ZConfig to
 create your application's configuration, but it's more common to
 include ZODB configuration strings in their own files or embedded in
 simpler configuration files, such as `configarser
@@ -115,7 +115,7 @@ URI-based configuration
 -----------------------
 
 Another database configuration option is provided by the `zodburi
-<https://pypi.python.org/pypi/zodburi>`_ package. See:
+<https://pypi.org/project/zodburi/>`_ package. See:
 http://docs.pylonsproject.org/projects/zodburi.  It's less powerful
 than the Python or text configuration options, but allows
 configuration to be reduced to a single URI and handles most cases.
@@ -205,7 +205,7 @@ need.  Often indexing data structures like BTrees_ are used to
 make it possible to search objects in large collections.
 
 .. [#zlibstoragefn] `zc.zlibstorage
-   <https://pypi.python.org/pypi/zc.zlibstorage>`_ is an optional
+   <https://pypi.org/project/zc.zlibstorage/>`_ is an optional
    package that you need to install separately.
 
 .. [#zlib] ZlibStorage uses the :mod:`zlib` standard module, which

--- a/doc/guide/transactions-and-threading.rst
+++ b/doc/guide/transactions-and-threading.rst
@@ -305,7 +305,7 @@ Which is shorter and simpler [#but-obscure]_.
 
 For Python web frameworks, there are WSGI [#wtf-wsgi]_ middle-ware
 components, such as `repoze.tm2
-<https://pypi.python.org/pypi/repoze.tm2>`_ that align transaction
+<https://pypi.org/project/repoze.tm2/>`_ that align transaction
 boundaries with HTTP requests and retry transactions when there are
 transient errors.
 

--- a/doc/guide/writing-persistent-objects.rst
+++ b/doc/guide/writing-persistent-objects.rst
@@ -220,12 +220,12 @@ entries in a ``TreeSet``, they must provide a `total ordering
 <https://pythonhosted.org/BTrees/#total-ordering-and-persistence>`_.
 The builtin python `str` class is always safe to use as BTree key. You
 can use `zope.keyreference
-<https://pypi.python.org/pypi/zope.keyreference>`_ to treat arbitrary
+<https://pypi.org/project/zope.keyreference/>`_ to treat arbitrary
 persistent objects as totally orderable based on their persistent
 object identity.
 
 Scalable sequences are a bit more challenging. The `zc.blist
-<https://pypi.python.org/pypi/zc.blist/>`_ package provides a scalable
+<https://pypi.org/project/zc.blist/>`_ package provides a scalable
 list implementation that works well for some sequence use cases.
 
 Properties
@@ -374,7 +374,7 @@ these are usually impractical for large databases.)
 
 An improvement to running migration scripts manually is to use a
 generational framework like `zope.generations
-<https://pypi.python.org/pypi/zope.generations>`_. With a generational
+<https://pypi.org/project/zope.generations/>`_. With a generational
 framework, each migration is assigned a migration number and the
 number is recorded in the database as each migration is run.  This is
 useful because remembering what migrations are needed is automated.
@@ -681,11 +681,11 @@ Links
 <http://persistent.readthedocs.io/en/latest/index.html>`_ provides
 additional documentation on the ``Persistent`` base class.
 
-The `zc.blist <https://pypi.python.org/pypi/zc.blist/>`_ package provides
+The `zc.blist <https://pypi.org/project/zc.blist/>`_ package provides
 a scalable sequence implementation for many use cases.
 
 The `zope.cachedescriptors
-<https://pypi.python.org/pypi/zope.cachedescriptors>`_ package
+<https://pypi.org/project/zope.cachedescriptors/>`_ package
 provides descriptor implementations that facilitate implementing
 caching attributes, especially ``_v_`` volatile attributes.
 
@@ -696,12 +696,12 @@ location, which is helpful when moving classes, especially persistent
 classes.
 
 The `zope.generations
-<https://pypi.python.org/pypi/zope.generations>`_ package provides a
+<https://pypi.org/project/zope.generations/>`_ package provides a
 framework for managing schema-migration scripts.
 
 
 .. [#cache] The `zope.cachedescriptors
-   <https://pypi.python.org/pypi/zope.cachedescriptors>`_ package
+   <https://pypi.org/project/zope.cachedescriptors/>`_ package
    provides some descriptors that help implement attributes that cache
    data.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -48,7 +48,7 @@ Downloads
 =========
 
 ZODB is distributed through the `Python Package Index
-<http://pypi.python.org/pypi/ZODB>`_.
+<https://pypi.org/project/ZODB/>`_.
 
 You can install the ZODB using pip command::
 

--- a/doc/reference/storages.rst
+++ b/doc/reference/storages.rst
@@ -192,24 +192,24 @@ ZRS
   For more information, see https://github.com/zc/zrs.
 
 zlibstorage
-  `zlibstorage <https://pypi.python.org/pypi/zc.zlibstorage>`_
+  `zlibstorage <https://pypi.org/project/zc.zlibstorage/>`_
   compresses database records using the compression
   algorithm used by `gzip <http://www.gzip.org/>`_.
 
-  For more information, see https://pypi.python.org/pypi/zc.zlibstorage.
+  For more information, see https://pypi.org/project/zc.zlibstorage/.
 
 beforestorage
-  `beforestorage <https://pypi.python.org/pypi/zc.beforestorage>`_
+  `beforestorage <https://pypi.org/project/zc.beforestorage/>`_
   provides a point-in-time view of a database that might
   be changing.  This can be useful to provide a non-changing view of a
   production database for use with a :class:`~ZODB.DemoStorage.DemoStorage`.
 
-  For more information, see https://pypi.python.org/pypi/zc.beforestorage.
+  For more information, see https://pypi.org/project/zc.beforestorage/.
 
 cipher.encryptingstorage
   `cipher.encryptingstorage
-  <https://pypi.python.org/pypi/cipher.encryptingstorage/>`_ provided
+  <https://pypi.org/project/cipher.encryptingstorage/>`_ provided
   compression and encryption of database records.
 
   For more information, see
-  https://pypi.python.org/pypi/cipher.encryptingstorage/.
+  https://pypi.org/project/cipher.encryptingstorage/.

--- a/src/ZODB/DemoStorage.py
+++ b/src/ZODB/DemoStorage.py
@@ -52,7 +52,7 @@ class DemoStorage(ConflictResolvingStorage):
     Demo storages are also handy for staging appplications where a
     read-only snapshot of a production database (often accomplished
     using a `beforestorage
-    <https://pypi.python.org/pypi/zc.beforestorage>`_) is combined
+    <https://pypi.org/project/zc.beforestorage/>`_) is combined
     with a changes database implemented with a
     :class:`~ZODB.FileStorage.FileStorage.FileStorage`.
     """


### PR DESCRIPTION
This PR updates the package URLs to the pypi.org domain and normalizes used protocol to HTTPS.