### PR TITLE
Relax assertion in check_tid_ordering_w_commit test

### DIFF
--- a/src/ZODB/tests/BasicStorage.py
+++ b/src/ZODB/tests/BasicStorage.py
@@ -348,16 +348,12 @@ class BasicStorage(object):
 
 
         @run_in_thread
-        def lastTransaction():
-            update_attempts()
-            results['lastTransaction'] = self._storage.lastTransaction()
-
-        @run_in_thread
         def load():
             update_attempts()
             results['load'] = utils.load_current(self._storage, ZERO)[1]
+            results['lastTransaction'] = self._storage.lastTransaction()
 
-        expected_attempts = 2
+        expected_attempts = 1
 
         if hasattr(self._storage, 'getTid'):
             expected_attempts += 1


### PR DESCRIPTION
It is pointless for lastTransaction() to block until it is allowed the
TID of a transaction that has just been committed, because it may still
not be the real last TID (e.g. for some storage implementations,
invalidations are received from a shared server via the network).
While invalidations are still being processed, it's fine to return
immediately with the previous last TID.

This was clarified in commit 4a6b0283f61427c7a2d8086a271bcdfb1cb53593
("mvccadapter: check if the last TID changed without invalidation").