### PR TITLE
Add a change note for #280

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,10 @@
 
 - Fix inconsistent resolution order with zope.interface v5.
 
+- Remove ``ConnectionPool.map()``. Instead, ``ConnectionPool`` is now
+  iterable. See `PR 280
+  <https://github.com/zopefoundation/ZODB/pull/280>`_.
+
 5.5.1 (2018-10-25)
 ==================
 


### PR DESCRIPTION
`ConnectionPool` and `ConnectionPool.map` both had docstrings and were used by third-party code. #280 removed that method but didn't leave a note. People should be warned about this potentially breaking change or they might find 5.6.0 to be surprising.

Even if the better thing to do is to restore `map()` in 5.6.1, I think 5.6.0 still needs a note. It's an easy thing to fix, at least in the cases I've seen that broke so I'm not too worried about it, as long as there's a heads-up.