### PR TITLE
Fix requirements for sphinx on python2

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -56,6 +56,7 @@ eggs = Sphinx
 eggs =
     Sphinx < 2
     pygments < 2.6
+    sphinxcontrib-websupport < 1.2
 
 [sphinx]
 recipe = zc.recipe.egg

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -10,6 +10,11 @@ parts =
 # Avoid breakage in 4.4.5:
 zope.testrunner = >= 4.4.6
 
+[versions:python2]
+Sphinx = < 2
+pygments = < 2.6
+sphinxcontrib-websupport = < 1.2
+
 [test]
 recipe = zc.recipe.testrunner
 eggs =
@@ -49,19 +54,10 @@ eggs =
     ${coverage-test:eggs}
 interpreter = py
 
-[sphinx_egg]
-eggs = Sphinx
-
-[sphinx_egg:python2 or python34]
-eggs =
-    Sphinx < 2
-    pygments < 2.6
-    sphinxcontrib-websupport < 1.2
-
 [sphinx]
 recipe = zc.recipe.egg
 eggs =
-    ${sphinx_egg:eggs}
+    Sphinx
     docutils
     ZODB
     sphinxcontrib_zopeext


### PR DESCRIPTION
Fix errors in test on python2.7 and pypy:
    
        from sphinxcontrib.serializinghtml.jsonimpl import dumps as dump_json
      File "/home/travis/build/zopefoundation/ZODB/eggs/sphinxcontrib_serializinghtml-1.1.4-py2.7.egg/sphinxcontrib/serializinghtml/__init__.py", line 177
        def setup(app: Sphinx) -> Dict[str, Any]:
                     ^
    SyntaxError: invalid syntax