### PR TITLE
fix variable name in get_refs function

### DIFF
--- a/src/ZODB/serialize.py
+++ b/src/ZODB/serialize.py
@@ -699,7 +699,7 @@ def get_refs(a_pickle):
         if isinstance(reference, tuple):
             oid, klass = reference
         elif isinstance(reference, (bytes, str)):
-            data, klass = reference, None
+            oid, klass = reference, None
         else:
             assert isinstance(reference, list)
             continue


### PR DESCRIPTION
I am getting error: local variable 'oid' referenced before assignment if reference is not tuple

```
for reference in refs:
        if isinstance(reference, tuple):
            oid, klass = reference
        elif isinstance(reference, (bytes, str)):
            data, klass = reference, None
        else:
            assert isinstance(reference, list)
            continue

        if not isinstance(oid, bytes):
            assert isinstance(oid, str)
            # this happens on Python 3 when all bytes in the oid are < 0x80
            oid = oid.encode('ascii')
```