### PR TITLE
WIP: fsrefs: Optimize IO

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@
 - Fix UnboundLocalError when running fsoids.py script.
   See `issue 268 <https://github.com/zopefoundation/ZODB/issues/285>`_.
 
+- Rework `fsrefs` script to work significantly faster by optimizing how it does
+  IO. See `PR 338 <https://github.com/zopefoundation/ZODB/pull/338>`.
 
 5.6.0 (2020-06-11)
 ==================

--- a/src/ZODB/scripts/fsrefs.py
+++ b/src/ZODB/scripts/fsrefs.py
@@ -63,7 +63,7 @@ in non-current revisions.
 """
 
 # implementation note: to save RAM we work with OIDs as with 64-bit integers
-# and keep references graph in LOBTree.
+# and keep references graph in QOBTree.
 
 from __future__ import print_function
 import traceback
@@ -73,7 +73,7 @@ from ZODB.TimeStamp import TimeStamp
 from ZODB.utils import u64, p64, oid_repr, get_pickle_metadata, load_current
 from ZODB.serialize import get_refs
 from ZODB.POSException import POSKeyError
-from BTrees.LOBTree import LOBTree, TreeSet as LTreeSet
+from BTrees.QOBTree import QOBTree, TreeSet as QTreeSet
 
 # There's a problem with oid.  'data' is its pickle, and 'serial' its
 # serial number.  'missing' is a list of (oid, class, reason) triples,
@@ -117,14 +117,14 @@ def main(path=None):
     # the object (the oid is still in the index, but its current data
     # record has a backpointer of 0, and POSKeyError is raised then
     # because of that backpointer).
-    undone = LTreeSet() # of oid
+    undone = QTreeSet() # of oid
 
     # Set of oids that were present in the index but failed to load.
     # This does not include oids in undone.
-    noload = LTreeSet() # of oid
+    noload = QTreeSet() # of oid
 
     #print("# building references graph ...")
-    graph = LOBTree() # oid -> refs   ; refs = [] of (oid, klass)
+    graph = QOBTree() # oid -> refs   ; refs = [] of (oid, klass)
 
     posoidv = list((pos, u64(oid)) for (oid, pos) in fs._index.items()) # [] of (pos, oid)
     posoidv.sort() # access objects in order of ascending file position  (optimize disk IO)


### PR DESCRIPTION
Update 2021-03-25: This patch turned out to require too much RAM (see https://github.com/zopefoundation/ZODB/pull/338#issuecomment-804539929 and below).
https://github.com/zopefoundation/ZODB/pull/340 is corrected version that still optimizes fsrefs, but does not require much RAM to work.

--------

- access objects in the order of their position in file
- load objects only once

This should give dramatical speedup when data are on HDD.

For example @perrinjerome reports that on a 73Go database it takes
almost 8h to run fsrefs (where on the same database, fstest takes 15
minutes). After the patch fsrefs took ~74 minutes to run on the same
database. In other words this is ~ 6.5x improvement.

Fsrefs has no tests. I tested it only lightly via generating a bit
corrupt database with deleted referred object(*), and it gives the same
output as unmodified fsrefs.

    oid 0x0 __main__.Object
    last updated: 1979-01-03 21:00:42.900001, tid=0x285cbacb70a3db3
    refers to invalid objects:
            oid 0x07 missing: '<unknown>'
            oid 0x07 object creation was undone: '<unknown>'

[1] https://lab.nexedi.com/nexedi/zodbtools/merge_requests/19#note_129480
[2] https://lab.nexedi.com/nexedi/zodbtools/merge_requests/19#note_129551

(*) test database generated via a bit modified gen_testdata.py from
zodbtools:

https://lab.nexedi.com/nexedi/zodbtools/blob/v0.0.0.dev8-28-g129afa6/zodbtools/test/gen_testdata.py +

```diff
--- a/zodbtools/test/gen_testdata.py
+++ b/zodbtools/test/gen_testdata.py
@@ -229,7 +229,7 @@ def ext(subj): return {}
         # delete an object
         name = random.choice(list(root.keys()))
         obj = root[name]
-        root[name] = Object("%s%i*" % (name, i))
+#       root[name] = Object("%s%i*" % (name, i))
         # NOTE user/ext are kept empty on purpose - to also test this case
         commit(u"", u"predelete %s" % unpack64(obj._p_oid), {})
```

/cc @tim-one, @jeremyhylton