### PR TITLE
DemoStorage: Add support for deleteObject (IExternalGC)

### DIFF
--- a/src/ZODB/BaseStorage.py
+++ b/src/ZODB/BaseStorage.py
@@ -59,7 +59,7 @@ class BaseStorage(UndoLogCompatible):
 
     If it stores multiple revisions, it should implement
     loadSerial()
-    loadBefore()
+    loadAt()
 
     Each storage will have two locks that are accessed via lock
     acquire and release methods bound to the instance.  (Yuck.)
@@ -267,9 +267,8 @@ class BaseStorage(UndoLogCompatible):
         raise POSException.Unsupported(
             "Retrieval of historical revisions is not supported")
 
-    def loadBefore(self, oid, tid):
-        """Return most recent revision of oid before tid committed."""
-        return None
+    # do not provide loadAt/loadBefore here in BaseStorage - if child forgets
+    # to override it - storage will always return "no data" instead of failing.
 
     def copyTransactionsFrom(self, other, verbose=0):
         """Copy transactions from another storage.

--- a/src/ZODB/DB.py
+++ b/src/ZODB/DB.py
@@ -726,8 +726,7 @@ class DB(object):
           - `before`: like `at`, but opens the readonly state before the
             tid or datetime.
         """
-        # `at` is normalized to `before`, since we use storage.loadBefore
-        # as the underlying implementation of both.
+        # `at` is normalized to `before`.
         before = getTID(at, before)
         if (before is not None and
             before > self.lastTransaction() and

--- a/src/ZODB/FileStorage/FileStorage.py
+++ b/src/ZODB/FileStorage/FileStorage.py
@@ -661,9 +661,10 @@ class FileStorage(
         with self._lock:
             old = self._index_get(oid, 0)
             if not old:
-                raise POSKeyError(oid)
-            h = self._read_data_header(old, oid)
-            committed_tid = h.tid
+                committed_tid = z64
+            else:
+                h = self._read_data_header(old, oid)
+                committed_tid = h.tid
 
             if oldserial != committed_tid:
                 raise ConflictError(

--- a/src/ZODB/blob.py
+++ b/src/ZODB/blob.py
@@ -866,10 +866,10 @@ class BlobStorage(BlobStorageMixin):
             for oid in self.fshelper.getOIDsForSerial(serial_id):
                 # we want to find the serial id of the previous revision
                 # of this blob object.
-                load_result = self.loadBefore(oid, serial_id)
+                at_before = utils.p64(utils.u64(serial_id)-1)
+                _, serial_before = utils.loadAt(self, oid, at_before)
 
-                if load_result is None:
-
+                if serial_before == utils.z64:
                     # There was no previous revision of this blob
                     # object.  The blob was created in the transaction
                     # represented by serial_id.  We copy the blob data
@@ -884,7 +884,6 @@ class BlobStorage(BlobStorageMixin):
                     # transaction implied by "serial_id".  We copy the blob
                     # data to a new file that references the undo transaction
                     # in case a user wishes to undo this undo.
-                    data, serial_before, serial_after = load_result
                     orig_fn = self.fshelper.getBlobFilename(oid, serial_before)
                     new_fn = self.fshelper.getBlobFilename(oid, undo_serial)
                 with open(orig_fn, "rb") as orig:

--- a/src/ZODB/historical_connections.rst
+++ b/src/ZODB/historical_connections.rst
@@ -36,7 +36,7 @@ development continues on a "development" head.
 
 A database can be opened historically ``at`` or ``before`` a given transaction
 serial or datetime. Here's a simple example. It should work with any storage
-that supports ``loadBefore``.
+that supports ``loadAt`` or ``loadBefore``.
 
 We'll begin our example with a fairly standard set up.  We
 
@@ -138,10 +138,9 @@ root.
     >>> historical_conn.root()['first']['count']
     0
 
-In fact, ``at`` arguments are translated into ``before`` values because the
-underlying mechanism is a storage's loadBefore method.  When you look at a
-connection's ``before`` attribute, it is normalized into a ``before`` serial,
-no matter what you pass into ``db.open``.
+In fact, ``at`` arguments are translated into ``before`` values.
+When you look at a connection's ``before`` attribute, it is normalized into a
+``before`` serial, no matter what you pass into ``db.open``.
 
     >>> print(conn.before)
     None

--- a/src/ZODB/interfaces.py
+++ b/src/ZODB/interfaces.py
@@ -710,6 +710,9 @@ class IStorage(Interface):
     def loadBefore(oid, tid):
         """Load the object data written before a transaction id
 
+        ( This method is deprecated and kept for backward-compatibility.
+          Please use loadAt instead. )
+
         If there isn't data before the object before the given
         transaction, then None is returned, otherwise three values are
         returned:
@@ -886,6 +889,24 @@ class IPrefetchStorage(IStorage):
         more than once.
         """
 
+class IStorageLoadAt(Interface):
+
+    def loadAt(oid, at): # -> (data, serial)
+        """Load object data as observed at given database state.
+
+        loadAt returns data for object with given object ID as observed by
+        database state ≤ at. Two values are returned:
+
+        - The data record,
+        - The transaction ID of the data record.
+
+        If the object does not exist, or is deleted as of `at` database state,
+        loadAt returns data=None, and serial indicates transaction ID of the
+        most recent deletion done in transaction with ID ≤ at, or null tid if
+        there is no such deletion.
+
+        Note: no POSKeyError is raised even if object id is not in the storage.
+        """
 
 class IMultiCommitStorage(IStorage):
     """A multi-commit storage can commit multiple transactions at once.

--- a/src/ZODB/mvccadapter.py
+++ b/src/ZODB/mvccadapter.py
@@ -10,7 +10,7 @@ also simplifies the implementation of the DB and Connection classes.
 import zope.interface
 
 from . import interfaces, serialize, POSException
-from .utils import p64, u64, Lock, oid_repr, tid_repr
+from .utils import p64, u64, z64, maxtid, Lock, loadAt, oid_repr, tid_repr
 
 class Base(object):
 
@@ -99,7 +99,7 @@ class MVCCAdapterInstance(Base):
         'checkCurrentSerialInTransaction', 'tpc_abort',
         )
 
-    _start = None # Transaction start time
+    _start = None # Transaction start time (before)
     _ltid = b''   # Last storage transaction id
 
     def __init__(self, base):
@@ -151,8 +151,20 @@ class MVCCAdapterInstance(Base):
 
     def load(self, oid):
         assert self._start is not None
-        r = self._storage.loadBefore(oid, self._start)
-        if r is None:
+        at = p64(u64(self._start)-1)
+        data, serial = loadAt(self._storage, oid, at)
+        if data is None:
+            # raise POSKeyError if object does not exist at all
+            # TODO raise POSKeyError always and switch to raising ReadOnlyError only when
+            # actually detecting that load is being affected by simultaneous pack (see below).
+            if serial == z64:
+                # XXX second call to loadAt - it will become unneeded once we
+                # switch to raising POSKeyError.
+                _, serial_exists = loadAt(self._storage, oid, maxtid)
+                if serial_exists == z64:
+                    # object does not exist at all
+                    raise POSException.POSKeyError(oid)
+
             # object was deleted or not-yet-created.
             # raise ReadConflictError - not - POSKeyError due to backward
             # compatibility: a pack(t+δ) could be running simultaneously to our
@@ -174,11 +186,14 @@ class MVCCAdapterInstance(Base):
             # whether pack is/was actually running and its details, take that
             # into account, and raise ReadConflictError only in the presence of
             # database being simultaneously updated from back of its log.
+            #
+            # See https://github.com/zopefoundation/ZODB/pull/322 for
+            # preliminary steps in this direction.
             raise POSException.ReadConflictError(
                     "load %s @%s: object deleted, likely by simultaneous pack" %
                     (oid_repr(oid), tid_repr(p64(u64(self._start) - 1))))
 
-        return r[:2]
+        return data, serial
 
     def prefetch(self, oids):
         try:
@@ -257,10 +272,11 @@ class HistoricalStorageAdapter(Base):
     new_oid = pack = store = read_only_writer
 
     def load(self, oid, version=''):
-        r = self._storage.loadBefore(oid, self._before)
-        if r is None:
+        at = p64(u64(self._before)-1)
+        data, serial = loadAt(self._storage, oid, at)
+        if data is None:
             raise POSException.POSKeyError(oid)
-        return r[:2]
+        return data, serial
 
 
 class UndoAdapterInstance(Base):

--- a/src/ZODB/tests/IExternalGC.test
+++ b/src/ZODB/tests/IExternalGC.test
@@ -16,6 +16,7 @@ A create_storage function is provided that creates a storage.
     >>> transaction.commit()
     >>> oid0 = conn.root()[0]._p_oid
     >>> oid1 = conn.root()[1]._p_oid
+    >>> atLive = conn.root()._p_serial
     >>> del conn.root()[0]
     >>> del conn.root()[1]
     >>> transaction.commit()
@@ -66,9 +67,10 @@ Now if we try to load data for the objects, we get a POSKeyError:
 
 We can still get the data if we load before the time we deleted.
 
-    >>> storage.loadBefore(oid0, conn.root()._p_serial) == (p0, s0, tid)
+    >>> from ZODB.utils import loadAt, z64
+    >>> loadAt(storage, oid0, atLive) == (p0, s0)
     True
-    >>> storage.loadBefore(oid1, conn.root()._p_serial) == (p1, s1, tid)
+    >>> loadAt(storage, oid1, atLive) == (p1, s1)
     True
     >>> with open(storage.loadBlob(oid1, s1)) as fp: fp.read()
     'some data'
@@ -92,15 +94,11 @@ gone:
     ...
     POSKeyError: ...
 
-    >>> storage.loadBefore(oid0, conn.root()._p_serial) # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-    ...
-    POSKeyError: ...
+    >>> loadAt(storage, oid0, atLive) == (None, z64)
+    True
 
-    >>> storage.loadBefore(oid1, conn.root()._p_serial) # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-    ...
-    POSKeyError: ...
+    >>> loadAt(storage, oid1, atLive) == (None, z64)
+    True
 
     >>> storage.loadBlob(oid1, s1) # doctest: +ELLIPSIS
     Traceback (most recent call last):

--- a/src/ZODB/tests/MVCCMappingStorage.py
+++ b/src/ZODB/tests/MVCCMappingStorage.py
@@ -46,6 +46,7 @@ class MVCCMappingStorage(MappingStorage):
         inst.new_oid = self.new_oid
         inst.pack = self.pack
         inst.loadBefore = self.loadBefore
+        inst.loadAt = self.loadAt
         inst._ltid = self._ltid
         inst._main_lock = self._lock
         return inst

--- a/src/ZODB/tests/hexstorage.py
+++ b/src/ZODB/tests/hexstorage.py
@@ -39,6 +39,13 @@ class HexStorage(object):
                 setattr(self, name, v)
 
         zope.interface.directlyProvides(self, zope.interface.providedBy(base))
+        if hasattr(base, 'loadAt') and 'loadAt' not in self.copied_methods:
+            def loadAt(oid, at):
+                data, serial = self.base.loadAt(oid, at)
+                if data is not None:
+                    data = unhexlify(data[2:])
+                return data, serial
+            self.loadAt = loadAt
 
     def __getattr__(self, name):
         return getattr(self.base, name)
@@ -130,7 +137,7 @@ class ServerHexStorage(HexStorage):
     """
 
     copied_methods = HexStorage.copied_methods + (
-        'load', 'loadBefore', 'loadSerial', 'store', 'restore',
+        'load', 'loadAt', 'loadBefore', 'loadSerial', 'store', 'restore',
         'iterator', 'storeBlob', 'restoreBlob', 'record_iternext',
         )
 

--- a/src/ZODB/tests/testConnection.py
+++ b/src/ZODB/tests/testConnection.py
@@ -1314,7 +1314,16 @@ class StubStorage(object):
             raise TypeError('StubStorage does not support versions.')
         return self._data[oid]
 
+    def loadAt(self, oid, at):
+        try:
+            data, serial = self._transdata[oid]
+        except KeyError:
+            return None, z64
+        return data, serial
+
     def loadBefore(self, oid, tid):
+        warnings.warn("loadBefore is deprecated - use loadAt instead",
+                DeprecationWarning, stacklevel=2)
         return self._data[oid] + (None, )
 
     def store(self, oid, serial, p, version, transaction):

--- a/src/ZODB/tests/testDemoStorage.py
+++ b/src/ZODB/tests/testDemoStorage.py
@@ -384,4 +384,12 @@ def test_suite():
     suite.addTest(unittest.makeSuite(DemoStorageWrappedAroundHexMappingStorage,
                                      'check'))
     suite.addTest(unittest.makeSuite(DemoStorageTests2, 'check'))
+
+    def demo_for_gctest():
+        from ZODB.FileStorage import FileStorage
+        base = ZODB.FileStorage.FileStorage('data.fs', blob_dir="data_blobs")
+        changes = ZODB.FileStorage.FileStorage('changes.fs', blob_dir="changes_blobs", pack_gc=False)
+        return ZODB.DemoStorage.DemoStorage(base=base, changes=changes)
+    suite.addTest(PackableStorage.IExternalGC_suite(demo_for_gctest))
+
     return suite

--- a/src/ZODB/tests/testmvcc.py
+++ b/src/ZODB/tests/testmvcc.py
@@ -35,7 +35,7 @@ MinimalMemoryStorage that implements MVCC support, but not much else.
 ***IMPORTANT***: The MVCC approach has changed since these tests were
 originally written. The new approach is much simpler because we no
 longer call load to get the current state of an object. We call
-loadBefore instead, having gotten a transaction time at the start of a
+loadAt instead, having gotten a transaction time at the start of a
 transaction.  As a result, the rhythm of the tests is a little odd,
 because we no longer need to probe a complex dance that doesn't exist any more.
 
@@ -290,7 +290,7 @@ first connection's state for b "old".
 
 Now deactivate "b" in the first connection, and (re)fetch it.  The first
 connection should still see 1, due to MVCC, but to get this old state
-TmpStore needs to handle the loadBefore() method.
+TmpStore needs to handle the loadAt() or loadBefore() methods.
 
 >>> r1["b"]._p_deactivate()
 
@@ -322,7 +322,7 @@ why ZODB no-longer calls load. :)
 
 Rather than add all the complexity of ZEO to these tests, the
 MinimalMemoryStorage has a hook.  We'll write a subclass that will
-deliver an invalidation when it loads (or loadBefore's) an object.
+deliver an invalidation when it loads (or loadAt's) an object.
 The hook allows us to test the Connection code.
 
 >>> class TestStorage(MinimalMemoryStorage):


### PR DESCRIPTION
So that it is generally possible to zodbrestore[1,2] zodbdumped[3]
database/transactions into DemoStorage. Because without this patch, when dump
contains deletion records, e.g.

    txn 0285cbacc06d3a4c " " 
    user ""
    description ""
    extension ""
    obj 0000000000000007 delete

it fails like this:

    Traceback (most recent call last):
      ...
      File "/home/kirr/src/wendelin/z/zodbtools/zodbtools/zodbrestore.py", line 94, in main
        zodbrestore(stor, asbinstream(sys.stdin), _)
      File "/home/kirr/src/wendelin/z/zodbtools/zodbtools/zodbrestore.py", line 43, in zodbrestore
        zodbcommit(stor, at, txn)
      File "/home/kirr/src/wendelin/z/zodbtools/zodbtools/zodbcommit.py", line 131, in zodbcommit
        _()
      File "/home/kirr/src/wendelin/z/zodbtools/zodbtools/zodbcommit.py", line 118, in _
        stor.deleteObject(obj.oid, current_serial(obj.oid), txn)
    AttributeError: 'DemoStorage' object has no attribute 'deleteObject'
        demo_test.go:105: demo:(file:///tmp/demo470143633/δ0285cbac258bf266/base.fs)/(file:///tmp/demo470143633/δ0285cbac258bf266/δ.fs): zpyrestore: exit status 1

To be able to implement DemoStorage.deleteObject, we have to fix 
FileStorage.deleteObject first: currently FileStorage.deleteObject raises
POSKeyError if an object is not present in the database, but for situation
where

- demo=base+δ,
- object is present in base, and 
- object is not present in δ

it creates a problem because there is no way to add whiteout record for the 
object into δ.

This change should be generally good; let me quote
https://lab.nexedi.com/kirr/neo/commit/543041a3 for why:

---- 8< ----
Even though currently it is not possible to create such data record via 
FileStorage(py).deleteObject (because it raises POSKeyError if there is
no previous object revision), being able to use such data records is
semantically useful in overlayed DemoStorage settings, where δ part
marks an object that exists only in base with delete record whiteout.

It is also generally meaningful to be able to create "delete" record
even if object was not previously existing: "deleteObject" is actually
similar to "store" (and so should be better named as "storeDelete"). If
one wants to store deletion, there should not be a reason to reject it, 
because deleteObject already has seatbelt in the form of oldserial, and 
if the user calls deleteObject(oid, oldserial=z64), he/she is already
telling that "I know that this object does not exist in this storage
(oldserial=z64), but still please create a deletion record for it". Once
again this is useful in overlayed DemoStorage settings described above.

For the reference, such whiteout deletion records pass ZODB/scripts/fstest just fine.
---- 8< ----

DemoStorage.deleteObject implementation is straightforward, but builds on
loadAt[4] as precondition.

/cc @jimfulton, @jamadden, @perrinjerome

[1] https://lab.nexedi.com/nexedi/zodbtools/blob/129afa67/zodbtools/zodbrestore.py
[2] https://lab.nexedi.com/nexedi/zodbtools/merge_requests/19
[3] https://lab.nexedi.com/nexedi/zodbtools/blob/129afa67/zodbtools/zodbdump.py
[4] https://github.com/zopefoundation/ZODB/pull/323
