### PR TITLE
Security fix documentation dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@
 - Rework ``fsrefs`` script to work significantly faster by optimizing how it does
   IO. See `PR 340 <https://github.com/zopefoundation/ZODB/pull/340>`_.
 
+- Require Python 3 to build the documentation.
+
+
 5.6.0 (2020-06-11)
 ==================
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
 Sphinx
+# Silence dependabot claiming a security issue in older versions:
 pygments >= 2.7.4
 docutils
 ZODB

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,5 @@
 Sphinx
-# pygments 2.6 stops the support for python2
-pygments<2.6
+pygments >= 2.7.4
 docutils
 ZODB
 sphinxcontrib_zopeext


### PR DESCRIPTION
According to dependabot Pygment versions < 2.7.4 are vulnerable.
I already switched https://readthedocs.org/projects/zodb-docs/ to Python 3.x.