### PR TITLE
mark `MVCCAdapter` instance's `tpc_finish` callbacks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@
 5.6.1 (unreleased)
 ==================
 
+- ``MVCCAdapter`` instances mark their ``tpc_finish`` callbacks
+  with the attribute ``invalidateTransaction == True``.
+  This can help storages to fullfil the requirement of ``ZODB>=5.6``
+  to let the value of ``lastTransaction`` change only after
+  invalidation processing.
+
 - Fix UnboundLocalError when running fsoids.py script.
   See `issue 285 <https://github.com/zopefoundation/ZODB/issues/285>`_.
 

--- a/src/ZODB/mvccadapter.py
+++ b/src/ZODB/mvccadapter.py
@@ -214,6 +214,9 @@ class MVCCAdapterInstance(Base):
             self._ltid = tid
             func(tid)
 
+        # inform the storage that the callback implements an
+        # optimized ``invalidateTransaction``
+        invalidate_finish.invalidateTransaction = True
         return self._storage.tpc_finish(transaction, invalidate_finish)
 
 def read_only_writer(self, *a, **kw):
@@ -299,4 +302,6 @@ class UndoAdapterInstance(Base):
             self._base._invalidate_finish(tid, self._undone, None)
             func(tid)
 
+        # tell the storage that the callback does the invalidation
+        invalidate_finish.invalidateTransaction = True
         self._storage.tpc_finish(transaction, invalidate_finish)


### PR DESCRIPTION
Since `ZODB>=5.6` `lastTransaction` must change after invalidation processing. The problem reported in "https://github.com/zopefoundation/ZEO/issues/166" demonstrates that this is necessary for the invalidations from a local `tpc_finish` as well.

`MVCCAdapter` instances put those invalidations into the `tpc_finish` callback. This implies that `lastTransaction` must change after those callbacks are run. The test `ZODB.tests.BasicStorage.BasicStorage.check_tid_ordering_w_commit` uses the `tpc_finish` callback to sample the result of `lastTransaction`. It requires that `lastTransaction` changes before the sampling. Obviously, both requirements contradict one another.

That the test currently succeeds for all storages almost surely means that those storages do not yet fulfill the requirement introduced by `ZODB==5.6`. The optimal approach likely would be to modify all storages and adapt the test accordingly. Because I do not want to change all storages at the moment, I opted for a different (slightly hacky) solution:
`MVCCAdapter` instances set `callback.invalidateTransaction = True` for their `tpc_finish` callbacks. This allows a storage implementation to distinguish callbacks from `MVCCAdapter` instances (`lastTransaction` must change after the callback) from other callbacks (e.g. from tests where `lastTransaction` might be expected to change before the callback).