### PR TITLE
tests: Add test for open vs invalidation race

### DIFF
--- a/src/ZODB/tests/BasicStorage.py
+++ b/src/ZODB/tests/BasicStorage.py
@@ -24,6 +24,7 @@ from ZODB.Connection import TransactionMetaData
 from ZODB.tests.MinPO import MinPO
 from ZODB.tests.StorageTestBase import zodb_unpickle, zodb_pickle
 from ZODB.tests.StorageTestBase import ZERO
+from ZODB.tests.util import with_high_concurrency
 
 import threading
 import time
@@ -392,6 +393,7 @@ class BasicStorage(object):
     # verify storage/Connection for race in between load/open and local invalidations.
     # https://github.com/zopefoundation/ZEO/issues/166
     # https://github.com/zopefoundation/ZODB/issues/290
+    @with_high_concurrency
     def check_race_loadopen_vs_local_invalidate(self):
         db = DB(self._storage)
 
@@ -498,6 +500,7 @@ class BasicStorage(object):
     # This test is similar to check_race_loadopen_vs_local_invalidate but does
     # not reuse its code because the probability to reproduce external
     # invalidation bug with only 1 mutator + 1 verifier is low.
+    @with_high_concurrency
     def check_race_load_vs_external_invalidate(self):
         # dbopen creates new client storage connection and wraps it with DB.
         def dbopen():

--- a/src/ZODB/tests/MVCCMappingStorage.py
+++ b/src/ZODB/tests/MVCCMappingStorage.py
@@ -112,11 +112,13 @@ class MVCCMappingStorage(MappingStorage):
 
     def tpc_finish(self, transaction, func = lambda tid: None):
         self._data_snapshot = None
-        return MappingStorage.tpc_finish(self, transaction, func)
+        with self._main_lock:
+            return MappingStorage.tpc_finish(self, transaction, func)
 
     def tpc_abort(self, transaction):
         self._data_snapshot = None
-        MappingStorage.tpc_abort(self, transaction)
+        with self._main_lock:
+            MappingStorage.tpc_abort(self, transaction)
 
     def pack(self, t, referencesf, gc=True):
         # prevent all concurrent commits during packing


### PR DESCRIPTION
Add test that exercises open vs invalidation race condition that, if
happen, leads to data corruption. We are seeing such race happening on
storage level in ZEO (https://github.com/zopefoundation/ZEO/issues/166),
and previously we've seen it also to happen on Connection level
(https://github.com/zopefoundation/ZODB/issues/290). By adding this test
to be exercised wrt all storages we make sure that all storages stay
free from this race.

And it payed out. Besides catching original problems from
https://github.com/zopefoundation/ZODB/issues/290 and
https://github.com/zopefoundation/ZEO/issues/166 , this test also
discovered a concurrency bug in MVCCMappingStorage:

    Failure in test check_race_open_vs_invalidate (ZODB.tests.testMVCCMappingStorage.MVCCMappingStorageTests)
    Traceback (most recent call last):
      File "/usr/lib/python2.7/unittest/case.py", line 329, in run
        testMethod()
      File "/home/kirr/src/wendelin/z/ZODB/src/ZODB/tests/BasicStorage.py", line 492, in check_race_open_vs_invalidate
        self.fail(failure[0])
      File "/usr/lib/python2.7/unittest/case.py", line 410, in fail
        raise self.failureException(msg)
    AssertionError: T1: obj1.value (24)  !=  obj2.value (23)

The problem with MVCCMappingStorage was that instance.poll_invalidations
was correctly taking main_lock with intention to make sure main data is
not mutated during analysis, but instance.tpc_finish and
instance.tpc_abort did _not_ taken main lock, which was leading to
committed data to be propagating into main storage in non-atomic way.

This bug was also observable if both obj1 and obj2 in the added test
were always loaded from the storage (added obj2._p_invalidate after
obj1._p_invalidate).

-> Fix MVCCMappingStorage by correctly locking main MVCCMappingStorage
instance when processing transaction completion.

/cc @d-maurer, @jamadden, @jmuchemb