### PR TITLE
Fix TypeError for fsoids

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 5.6.1 (unreleased)
 ==================
 
+- Fix ``TypeError: can't concat str to bytes`` when running fsoids.py script with Python 3.
+  See `issue 350 <https://github.com/zopefoundation/ZODB/issues/350>`_.
+
 - Fix UnboundLocalError when running fsoids.py script.
   See `issue 285 <https://github.com/zopefoundation/ZODB/issues/285>`_.
 

--- a/src/ZODB/FileStorage/fsoids.py
+++ b/src/ZODB/FileStorage/fsoids.py
@@ -29,7 +29,11 @@ def shorten(s, size=50):
     navail = size - 5
     nleading = navail // 2
     ntrailing = size - nleading
-    return s[:nleading] + " ... " + s[-ntrailing:]
+    if isinstance(s, bytes):
+        sep = b" ... "
+    else:
+        sep = " ... "
+    return s[:nleading] + sep + s[-ntrailing:]
 
 class Tracer(object):
     """Trace all occurrences of a set of oids in a FileStorage.


### PR DESCRIPTION
Fix ``TypeError: can't concat str to bytes`` when running fsoids.py script with Python 3.

Closes #350