### PR TITLE
Fix deprecation warnings occurring on Python 3.10.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@
 
 - Require Python 3 to build the documentation.
 
+- Fix deprecation warnings occurring on Python 3.10.
+
 
 5.6.0 (2020-06-11)
 ==================

--- a/src/ZODB/FileStorage/FileStorage.py
+++ b/src/ZODB/FileStorage/FileStorage.py
@@ -2161,7 +2161,7 @@ class FilePool(object):
                 self.writing = False
                 if self.writers > 0:
                     self.writers -= 1
-                self._cond.notifyAll()
+                self._cond.notify_all()
 
     @contextlib.contextmanager
     def get(self):
@@ -2186,7 +2186,7 @@ class FilePool(object):
             if not self._out:
                 with self._cond:
                     if self.writers and not self._out:
-                        self._cond.notifyAll()
+                        self._cond.notify_all()
 
     def empty(self):
         while self._files:

--- a/src/ZODB/scripts/fsstats.py
+++ b/src/ZODB/scripts/fsstats.py
@@ -6,8 +6,8 @@ import sys
 import six
 from six.moves import filter
 
-rx_txn = re.compile("tid=([0-9a-f]+).*size=(\d+)")
-rx_data = re.compile("oid=([0-9a-f]+) size=(\d+) class=(\S+)")
+rx_txn = re.compile(r"tid=([0-9a-f]+).*size=(\d+)")
+rx_data = re.compile(r"oid=([0-9a-f]+) size=(\d+) class=(\S+)")
 
 def sort_byhsize(seq, reverse=False):
     L = [(v.size(), k, v) for k, v in seq]

--- a/src/ZODB/tests/BasicStorage.py
+++ b/src/ZODB/tests/BasicStorage.py
@@ -209,7 +209,7 @@ class BasicStorage(object):
         # We'll run the competing trans in a separate thread:
         thread = threading.Thread(name='T2',
             target=self._dostore, args=(oid,), kwargs=dict(revid=revid))
-        thread.setDaemon(True)
+        thread.daemon = True
         thread.start()
         thread.join(.1)
         return thread
@@ -324,7 +324,7 @@ class BasicStorage(object):
         to_join = []
         def run_in_thread(func):
             t = threading.Thread(target=func)
-            t.setDaemon(True)
+            t.daemon = True
             t.start()
             to_join.append(t)
 
@@ -347,7 +347,7 @@ class BasicStorage(object):
         def update_attempts():
             with attempts_cond:
                 attempts.append(1)
-                attempts_cond.notifyAll()
+                attempts_cond.notify_all()
 
 
         @run_in_thread

--- a/src/ZODB/tests/MTStorage.py
+++ b/src/ZODB/tests/MTStorage.py
@@ -50,7 +50,7 @@ class ZODBClientThread(TestThread):
 
     def __init__(self, db, test, commits=10, delay=SHORT_DELAY):
         self.__super_init()
-        self.setDaemon(1)
+        self.daemon = True
         self.db = db
         self.test = test
         self.commits = commits
@@ -76,7 +76,7 @@ class ZODBClientThread(TestThread):
         time.sleep(self.delay)
 
     # Return a new PersistentMapping, and store it on the root object under
-    # the name (.getName()) of the current thread.
+    # the name of the current thread.
     def get_thread_dict(self, root):
         # This is vicious:  multiple threads are slamming changes into the
         # root object, then trying to read the root object, simultaneously
@@ -86,7 +86,7 @@ class ZODBClientThread(TestThread):
         # around (at most) 1000 times was enough so that a 100-thread test
         # reliably passed on Tim's hyperthreaded WinXP box (but at the
         # original 10 retries, the same test reliably failed with 15 threads).
-        name = self.getName()
+        name = self.name
         MAXRETRIES = 1000
 
         for i in range(MAXRETRIES):
@@ -129,7 +129,7 @@ class StorageClientThread(TestThread):
             data, serial = load_current(self.storage, oid)
             self.test.assertEqual(serial, revid)
             obj = zodb_unpickle(data)
-            self.test.assertEqual(obj.value[0], self.getName())
+            self.test.assertEqual(obj.value[0], self.name)
 
     def pause(self):
         time.sleep(self.delay)
@@ -140,7 +140,7 @@ class StorageClientThread(TestThread):
         return oid
 
     def dostore(self, i):
-        data = zodb_pickle(MinPO((self.getName(), i)))
+        data = zodb_pickle(MinPO((self.name, i)))
         t = TransactionMetaData()
         oid = self.oid()
         self.pause()

--- a/src/ZODB/tests/testThreadedShutdown.py
+++ b/src/ZODB/tests/testThreadedShutdown.py
@@ -12,7 +12,7 @@ class ZODBClientThread(threading.Thread):
     def __init__(self, db, test):
         threading.Thread.__init__(self)
         self._exc_info = None
-        self.setDaemon(True)
+        self.daemon = True
         self.db = db
         self.test = test
         self.event = threading.Event()


### PR DESCRIPTION
The alternative method names resp. attributes have been introduced in Python 2.6. The ones used here are deprecated since than.

I am planning to use `meta/config` in this repository so Python 3.10 gets tested in GHA.
