### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/articles/ZODB2.rst
+++ b/docs/articles/ZODB2.rst
@@ -315,11 +315,11 @@ transactions object::
 
 Subtransactions, sometimes called "inner transactions", are
 transactions that happen inside another transaction.
-Subtransactions can be commited and aborted like regular "outer"
+Subtransactions can be committed and aborted like regular "outer"
 transactions.  Subtransactions mostly provide you with an
 optimization technique.
 
-Subtransactions can be commited and aborted.  Commiting or
+Subtransactions can be committed and aborted.  Commiting or
 aborting a subtransaction does not commit or abort its outer
 transaction, just the subtransaction.  This lets you use many,
 fine-grained transactions within one big transaction.
@@ -336,7 +336,7 @@ If you abort an outer transaction, then all of its inner
 subtransactions will also be aborted and not saved.  If you abort
 an inner subtransaction, then only the changes made during that
 subtransaction are aborted, and the outer transaction is *not*
-aborted and more changes can be made and commited, including more
+aborted and more changes can be made and committed, including more
 subtransactions.
 
 You can commit or abort a subtransaction by calling either

--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -1069,7 +1069,7 @@ class Connection(ExportImport, object):
         # by another thread, so the risk of a reread is pretty low.
         # It's really not worth the effort to pursue this.
 
-        # Note that we do this *after* reseting the storage so that, if
+        # Note that we do this *after* resetting the storage so that, if
         # data are read, we read it from the reset storage!
 
         self._cache.invalidate(src.index)

--- a/src/ZODB/FileStorage/fsdump.py
+++ b/src/ZODB/FileStorage/fsdump.py
@@ -62,7 +62,7 @@ def fmt(p64):
 
 
 class Dumper(object):
-    """A very verbose dumper for debuggin FileStorage problems."""
+    """A very verbose dumper for debugging FileStorage problems."""
 
     # TODO:  Should revise this class to use FileStorageFormatter.
 

--- a/src/ZODB/cross-database-references.rst
+++ b/src/ZODB/cross-database-references.rst
@@ -144,7 +144,7 @@ the ambiguity.
 Dissallowing implicit cross-database references
 ===============================================
 
-The database contructor accepts a xrefs keyword argument that defaults
+The database constructor accepts a xrefs keyword argument that defaults
 to True.  If False is passed, the implicit cross database references
 are disallowed. (Note that currently, implicit cross references are
 the only kind of cross references allowed.)

--- a/src/ZODB/tests/testblob.py
+++ b/src/ZODB/tests/testblob.py
@@ -624,7 +624,7 @@ def savepoint_isolation():
 
 
 def savepoint_commits_without_invalidations_out_of_order():
-    """Make sure transactions with blobs can be commited without the
+    """Make sure transactions with blobs can be committed without the
     invalidations out of order error (LP #509801)
 
     >>> bs = create_storage()  # noqa: F821 undefined name


### PR DESCRIPTION
There are small typos in:
- docs/articles/ZODB2.rst
- src/ZODB/Connection.py
- src/ZODB/FileStorage/fsdump.py
- src/ZODB/cross-database-references.rst
- src/ZODB/tests/testblob.py

Fixes:
- Should read `committed` rather than `commited`.
- Should read `resetting` rather than `reseting`.
- Should read `debugging` rather than `debuggin`.
- Should read `constructor` rather than `contructor`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md