### PR TITLE
Modernize race tests and add test that catches ZEO corruption on invalidation / disconnect 

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -14,6 +14,9 @@ with-sphinx-doctests = false
 
 [tox]
 use-flake8 = true
+testenv-commands = [
+    "zope-testrunner --test-path=src --all {posargs:-vc}",
+    ]
 testenv-setenv = [
     "ZOPE_INTERFACE_STRICT_IRO=1",
     ]

--- a/src/ZODB/tests/BasicStorage.py
+++ b/src/ZODB/tests/BasicStorage.py
@@ -18,24 +18,22 @@ http://www.zope.org/Documentation/Developer/Models/ZODB/ZODB_Architecture_Storag
 
 All storages should be able to pass these tests.
 """
-import transaction
-from ZODB import DB, POSException
+from ZODB import POSException
 from ZODB.Connection import TransactionMetaData
 from ZODB.tests.MinPO import MinPO
 from ZODB.tests.StorageTestBase import zodb_unpickle, zodb_pickle
 from ZODB.tests.StorageTestBase import ZERO
-from ZODB.tests.util import with_high_concurrency
+from ZODB.tests.racetest import RaceTests
 
 import threading
 import time
 import zope.interface
 import zope.interface.verify
-from random import randint
 
 from .. import utils
 
 
-class BasicStorage(object):
+class BasicStorage(RaceTests):
     def checkBasics(self):
         self.assertEqual(self._storage.lastTransaction(), ZERO)
 
@@ -392,239 +390,3 @@ class BasicStorage(object):
         self.assertEqual(results.pop('lastTransaction'), tids[1])
         for m, tid in results.items():
             self.assertEqual(tid, tids[1])
-
-    # verify storage/Connection for race in between load/open and local
-    # invalidations.
-    # https://github.com/zopefoundation/ZEO/issues/166
-    # https://github.com/zopefoundation/ZODB/issues/290
-
-    @with_high_concurrency
-    def check_race_loadopen_vs_local_invalidate(self):
-        db = DB(self._storage)
-
-        # init initializes the database with two integer objects - obj1/obj2
-        # that are set to 0.
-        def init():
-            transaction.begin()
-            zconn = db.open()
-
-            root = zconn.root()
-            root['obj1'] = MinPO(0)
-            root['obj2'] = MinPO(0)
-
-            transaction.commit()
-            zconn.close()
-
-        # verify accesses obj1/obj2 and verifies that obj1.value == obj2.value
-        #
-        # access to obj1 is organized to always trigger loading from zstor.
-        # access to obj2 goes through zconn cache and so verifies whether the
-        # cache is not stale.
-        failed = threading.Event()
-        failure = [None]
-
-        def verify():
-            transaction.begin()
-            zconn = db.open()
-
-            root = zconn.root()
-            obj1 = root['obj1']
-            obj2 = root['obj2']
-
-            # obj1 - reload it from zstor
-            # obj2 - get it from zconn cache
-            obj1._p_invalidate()
-
-            # both objects must have the same values
-            v1 = obj1.value
-            v2 = obj2.value
-            if v1 != v2:
-                failure[0] = "verify: obj1.value (%d)  !=  obj2.value (%d)" % (
-                    v1, v2)
-                failed.set()
-
-            # we did not changed anything; also fails with commit:
-            transaction.abort()
-            zconn.close()
-
-        # modify changes obj1/obj2 by doing `objX.value += 1`.
-        #
-        # Since both objects start from 0, the invariant that
-        # `obj1.value == obj2.value` is always preserved.
-        def modify():
-            transaction.begin()
-            zconn = db.open()
-
-            root = zconn.root()
-            obj1 = root['obj1']
-            obj2 = root['obj2']
-            obj1.value += 1
-            obj2.value += 1
-            assert obj1.value == obj2.value
-
-            transaction.commit()
-            zconn.close()
-
-        # xrun runs f in a loop until either N iterations, or until failed is
-        # set.
-        def xrun(f, N):
-            try:
-                for i in range(N):
-                    # print('%s.%d' % (f.__name__, i))
-                    f()
-                    if failed.is_set():
-                        break
-            except:  # noqa: E722 do not use bare 'except'
-                failed.set()
-                raise
-
-        # loop verify and modify concurrently.
-        init()
-
-        N = 500
-        tverify = threading.Thread(
-            name='Tverify', target=xrun, args=(verify, N))
-        tmodify = threading.Thread(
-            name='Tmodify', target=xrun, args=(modify, N))
-        tverify.start()
-        tmodify.start()
-        tverify.join(60)
-        tmodify.join(60)
-
-        if failed.is_set():
-            self.fail(failure[0])
-
-    # client-server storages like ZEO, NEO and RelStorage allow several storage
-    # clients to be connected to single storage server.
-    #
-    # For client-server storages test subclasses should implement
-    # _new_storage_client to return new storage client that is connected to the
-    # same storage server self._storage is connected to.
-
-    def _new_storage_client(self):
-        raise NotImplementedError
-
-    # verify storage for race in between load and external invalidations.
-    # https://github.com/zopefoundation/ZEO/issues/155
-    #
-    # This test is similar to check_race_loadopen_vs_local_invalidate but does
-    # not reuse its code because the probability to reproduce external
-    # invalidation bug with only 1 mutator + 1 verifier is low.
-    @with_high_concurrency
-    def check_race_load_vs_external_invalidate(self):
-        # dbopen creates new client storage connection and wraps it with DB.
-        def dbopen():
-            try:
-                zstor = self._new_storage_client()
-            except NotImplementedError:
-                # the test will be skipped from main thread because dbopen is
-                # first used in init on the main thread before any other thread
-                # is spawned.
-                self.skipTest(
-                    "%s does not implement _new_storage_client" % type(self))
-            return DB(zstor)
-
-        # init initializes the database with two integer objects - obj1/obj2
-        # that are set to 0.
-        def init():
-            db = dbopen()
-
-            transaction.begin()
-            zconn = db.open()
-
-            root = zconn.root()
-            root['obj1'] = MinPO(0)
-            root['obj2'] = MinPO(0)
-
-            transaction.commit()
-            zconn.close()
-
-            db.close()
-
-        # we'll run 8 T workers concurrently. As of 20210416, due to race
-        # conditions in ZEO, it triggers the bug where T sees stale obj2 with
-        # obj1.value != obj2.value
-        #
-        # The probability to reproduce the bug is significantly reduced with
-        # decreasing n(workers): almost never with nwork=2 and sometimes with
-        # nwork=4.
-        nwork = 8
-
-        # T is a worker that accesses obj1/obj2 in a loop and verifies
-        # `obj1.value == obj2.value` invariant.
-        #
-        # access to obj1 is organized to always trigger loading from zstor.
-        # access to obj2 goes through zconn cache and so verifies whether the
-        # cache is not stale.
-        #
-        # Once in a while T tries to modify obj{1,2}.value maintaining the
-        # invariant as test source of changes for other workers.
-        failed = threading.Event()
-        failure = [None] * nwork  # [tx] is failure from T(tx)
-
-        def T(tx, N):
-            db = dbopen()
-
-            def t_():
-                transaction.begin()
-                zconn = db.open()
-
-                root = zconn.root()
-                obj1 = root['obj1']
-                obj2 = root['obj2']
-
-                # obj1 - reload it from zstor
-                # obj2 - get it from zconn cache
-                obj1._p_invalidate()
-
-                # both objects must have the same values
-                i1 = obj1.value
-                i2 = obj2.value
-                if i1 != i2:
-                    # print('FAIL')
-                    failure[tx] = (
-                        "T%s: obj1.value (%d)  !=  obj2.value (%d)" % (
-                            tx, i1, i2))
-                    failed.set()
-
-                # change objects once in a while
-                if randint(0, 4) == 0:
-                    # print("T%s: modify" % tx)
-                    obj1.value += 1
-                    obj2.value += 1
-
-                try:
-                    transaction.commit()
-                except POSException.ConflictError:
-                    # print('conflict -> ignore')
-                    transaction.abort()
-
-                zconn.close()
-
-            try:
-                for i in range(N):
-                    # print('T%s.%d' % (tx, i))
-                    t_()
-                    if failed.is_set():
-                        break
-            except:  # noqa: E722 do not use bare 'except'
-                failed.set()
-                raise
-            finally:
-                db.close()
-
-        # run the workers concurrently.
-        init()
-
-        N = 100
-        tg = []
-        for x in range(nwork):
-            t = threading.Thread(name='T%d' % x, target=T, args=(x, N))
-            t.start()
-            tg.append(t)
-
-        for t in tg:
-            t.join(60)
-
-        if failed.is_set():
-            self.fail([_ for _ in failure if _])

--- a/src/ZODB/tests/racetest.py
+++ b/src/ZODB/tests/racetest.py
@@ -46,12 +46,13 @@ from ZODB import DB, POSException
 from ZODB.utils import tid_repr, at2before
 from ZODB.tests.MinPO import MinPO
 from ZODB.tests.util import with_high_concurrency, long_test
+from zope.interface import Interface, implementer
 
 import threading
 from random import randint
 
 
-class ISpec:
+class ISpec(Interface):
     """ISpec interface represents testing specification used by check_race_*"""
 
     def init(root):
@@ -68,7 +69,8 @@ class ISpec:
         """
 
 
-class T2ObjectsInc(ISpec):
+@implementer(ISpec)
+class T2ObjectsInc:
     """T2ObjectsInc is specification with behaviour where two objects obj1
     and obj2 are incremented synchronously.
 
@@ -93,7 +95,8 @@ class T2ObjectsInc(ISpec):
             raise AssertionError("obj1 (%d)  !=  obj2 (%d)" % (i1, i2))
 
 
-class T2ObjectsInc2Phase(ISpec):
+@implementer(ISpec)
+class T2ObjectsInc2Phase:
     """T2ObjectsInc2Phase is specification with behaviour where two objects
     obj1 and obj2 are incremented in lock-step.
 
@@ -137,7 +140,7 @@ class RaceTests(object):
 
     @with_high_concurrency
     def _check_race_loadopen_vs_local_invalidate(self, spec):
-        assert isinstance(spec, ISpec)
+        assert ISpec.providedBy(spec)
         db = DB(self._storage)
 
         # init initializes the database according to the spec.
@@ -249,7 +252,7 @@ class RaceTests(object):
 
     @with_high_concurrency
     def _check_race_load_vs_external_invalidate(self, spec):
-        assert isinstance(spec, ISpec)
+        assert ISpec.providedBy(spec)
 
         # init initializes the database according to the spec.
         def init():
@@ -359,7 +362,7 @@ class RaceTests(object):
 
     @with_high_concurrency
     def _check_race_xxx_vs_external_disconnect(self, spec):
-        assert isinstance(spec, ISpec)
+        assert ISpec.providedBy(spec)
 
         # init initializes the database according to the spec.
         def init():

--- a/src/ZODB/tests/racetest.py
+++ b/src/ZODB/tests/racetest.py
@@ -45,7 +45,7 @@ import transaction
 from ZODB import DB, POSException
 from ZODB.utils import tid_repr, at2before
 from ZODB.tests.MinPO import MinPO
-from ZODB.tests.util import with_high_concurrency
+from ZODB.tests.util import with_high_concurrency, long_test
 
 import threading
 from random import randint
@@ -352,6 +352,7 @@ class RaceTests(object):
     # state, or in new state after the next transaction. Contrary to that, with
     # T2ObjectsInc2Phase the invariant will be detected to be broken on the
     # next transaction.
+    @long_test
     def check_race_external_invalidate_vs_disconnect(self):
         return self._check_race_xxx_vs_external_disconnect(
                                                 T2ObjectsInc2Phase())

--- a/src/ZODB/tests/racetest.py
+++ b/src/ZODB/tests/racetest.py
@@ -1,0 +1,263 @@
+##############################################################################
+#
+# Copyright (c) 2019 - 2022 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""Module racetest provides infrastructure and tests to verify storages against
+data corruptions caused by race conditions in storages implementations.
+"""
+
+import transaction
+from ZODB import DB, POSException
+from ZODB.tests.MinPO import MinPO
+from ZODB.tests.util import with_high_concurrency
+
+import threading
+from random import randint
+
+
+class RaceTests(object):
+
+    # verify storage/Connection for race in between load/open and local
+    # invalidations.
+    # https://github.com/zopefoundation/ZEO/issues/166
+    # https://github.com/zopefoundation/ZODB/issues/290
+
+    @with_high_concurrency
+    def check_race_loadopen_vs_local_invalidate(self):
+        db = DB(self._storage)
+
+        # init initializes the database with two integer objects - obj1/obj2
+        # that are set to 0.
+        def init():
+            transaction.begin()
+            zconn = db.open()
+
+            root = zconn.root()
+            root['obj1'] = MinPO(0)
+            root['obj2'] = MinPO(0)
+
+            transaction.commit()
+            zconn.close()
+
+        # verify accesses obj1/obj2 and verifies that obj1.value == obj2.value
+        #
+        # access to obj1 is organized to always trigger loading from zstor.
+        # access to obj2 goes through zconn cache and so verifies whether the
+        # cache is not stale.
+        failed = threading.Event()
+        failure = [None]
+
+        def verify():
+            transaction.begin()
+            zconn = db.open()
+
+            root = zconn.root()
+            obj1 = root['obj1']
+            obj2 = root['obj2']
+
+            # obj1 - reload it from zstor
+            # obj2 - get it from zconn cache
+            obj1._p_invalidate()
+
+            # both objects must have the same values
+            v1 = obj1.value
+            v2 = obj2.value
+            if v1 != v2:
+                failure[0] = "verify: obj1.value (%d)  !=  obj2.value (%d)" % (
+                    v1, v2)
+                failed.set()
+
+            # we did not changed anything; also fails with commit:
+            transaction.abort()
+            zconn.close()
+
+        # modify changes obj1/obj2 by doing `objX.value += 1`.
+        #
+        # Since both objects start from 0, the invariant that
+        # `obj1.value == obj2.value` is always preserved.
+        def modify():
+            transaction.begin()
+            zconn = db.open()
+
+            root = zconn.root()
+            obj1 = root['obj1']
+            obj2 = root['obj2']
+            obj1.value += 1
+            obj2.value += 1
+            assert obj1.value == obj2.value
+
+            transaction.commit()
+            zconn.close()
+
+        # xrun runs f in a loop until either N iterations, or until failed is
+        # set.
+        def xrun(f, N):
+            try:
+                for i in range(N):
+                    # print('%s.%d' % (f.__name__, i))
+                    f()
+                    if failed.is_set():
+                        break
+            except:  # noqa: E722 do not use bare 'except'
+                failed.set()
+                raise
+
+        # loop verify and modify concurrently.
+        init()
+
+        N = 500
+        tverify = threading.Thread(
+            name='Tverify', target=xrun, args=(verify, N))
+        tmodify = threading.Thread(
+            name='Tmodify', target=xrun, args=(modify, N))
+        tverify.start()
+        tmodify.start()
+        tverify.join(60)
+        tmodify.join(60)
+
+        if failed.is_set():
+            self.fail(failure[0])
+
+    # client-server storages like ZEO, NEO and RelStorage allow several storage
+    # clients to be connected to single storage server.
+    #
+    # For client-server storages test subclasses should implement
+    # _new_storage_client to return new storage client that is connected to the
+    # same storage server self._storage is connected to.
+
+    def _new_storage_client(self):
+        raise NotImplementedError
+
+    # verify storage for race in between load and external invalidations.
+    # https://github.com/zopefoundation/ZEO/issues/155
+    #
+    # This test is similar to check_race_loadopen_vs_local_invalidate but does
+    # not reuse its code because the probability to reproduce external
+    # invalidation bug with only 1 mutator + 1 verifier is low.
+    @with_high_concurrency
+    def check_race_load_vs_external_invalidate(self):
+        # dbopen creates new client storage connection and wraps it with DB.
+        def dbopen():
+            try:
+                zstor = self._new_storage_client()
+            except NotImplementedError:
+                # the test will be skipped from main thread because dbopen is
+                # first used in init on the main thread before any other thread
+                # is spawned.
+                self.skipTest(
+                    "%s does not implement _new_storage_client" % type(self))
+            return DB(zstor)
+
+        # init initializes the database with two integer objects - obj1/obj2
+        # that are set to 0.
+        def init():
+            db = dbopen()
+
+            transaction.begin()
+            zconn = db.open()
+
+            root = zconn.root()
+            root['obj1'] = MinPO(0)
+            root['obj2'] = MinPO(0)
+
+            transaction.commit()
+            zconn.close()
+
+            db.close()
+
+        # we'll run 8 T workers concurrently. As of 20210416, due to race
+        # conditions in ZEO, it triggers the bug where T sees stale obj2 with
+        # obj1.value != obj2.value
+        #
+        # The probability to reproduce the bug is significantly reduced with
+        # decreasing n(workers): almost never with nwork=2 and sometimes with
+        # nwork=4.
+        nwork = 8
+
+        # T is a worker that accesses obj1/obj2 in a loop and verifies
+        # `obj1.value == obj2.value` invariant.
+        #
+        # access to obj1 is organized to always trigger loading from zstor.
+        # access to obj2 goes through zconn cache and so verifies whether the
+        # cache is not stale.
+        #
+        # Once in a while T tries to modify obj{1,2}.value maintaining the
+        # invariant as test source of changes for other workers.
+        failed = threading.Event()
+        failure = [None] * nwork  # [tx] is failure from T(tx)
+
+        def T(tx, N):
+            db = dbopen()
+
+            def t_():
+                transaction.begin()
+                zconn = db.open()
+
+                root = zconn.root()
+                obj1 = root['obj1']
+                obj2 = root['obj2']
+
+                # obj1 - reload it from zstor
+                # obj2 - get it from zconn cache
+                obj1._p_invalidate()
+
+                # both objects must have the same values
+                i1 = obj1.value
+                i2 = obj2.value
+                if i1 != i2:
+                    # print('FAIL')
+                    failure[tx] = (
+                        "T%s: obj1.value (%d)  !=  obj2.value (%d)" % (
+                            tx, i1, i2))
+                    failed.set()
+
+                # change objects once in a while
+                if randint(0, 4) == 0:
+                    # print("T%s: modify" % tx)
+                    obj1.value += 1
+                    obj2.value += 1
+
+                try:
+                    transaction.commit()
+                except POSException.ConflictError:
+                    # print('conflict -> ignore')
+                    transaction.abort()
+
+                zconn.close()
+
+            try:
+                for i in range(N):
+                    # print('T%s.%d' % (tx, i))
+                    t_()
+                    if failed.is_set():
+                        break
+            except:  # noqa: E722 do not use bare 'except'
+                failed.set()
+                raise
+            finally:
+                db.close()
+
+        # run the workers concurrently.
+        init()
+
+        N = 100
+        tg = []
+        for x in range(nwork):
+            t = threading.Thread(name='T%d' % x, target=T, args=(x, N))
+            t.start()
+            tg.append(t)
+
+        for t in tg:
+            t.join(60)
+
+        if failed.is_set():
+            self.fail([_ for _ in failure if _])

--- a/src/ZODB/tests/racetest.py
+++ b/src/ZODB/tests/racetest.py
@@ -144,11 +144,12 @@ class RaceTests(object):
         assert IModelSpec.providedBy(spec)
         db = DB(self._storage)
 
-        # init initializes the database according to the spec.
+        # `init` initializes the database according to the spec.
         def init():
             _state_init(db, spec)
 
-        # verify accesses objects in the database and verifies spec invariant.
+        # `verify` accesses objects in the database and verifies spec
+        # invariant.
         #
         # Access to half of the objects is organized to always trigger loading
         # from zstor. Access to the other half goes through zconn cache and so
@@ -177,7 +178,7 @@ class RaceTests(object):
             transaction.abort()
             zconn.close()
 
-        # modify changes objects in the database by executing "next" step.
+        # `modify` changes objects in the database by executing "next" step.
         #
         # Spec invariant should be preserved.
         def modify():
@@ -191,7 +192,7 @@ class RaceTests(object):
             transaction.commit()
             zconn.close()
 
-        # xrun runs f in a loop until either N iterations, or until failed is
+        # `xrun` runs f in a loop until either N iterations, or until failed is
         # set.
         def xrun(f, N):
             try:
@@ -230,7 +231,7 @@ class RaceTests(object):
     def _new_storage_client(self):
         raise NotImplementedError
 
-    # dbopen creates new client storage connection and wraps it with DB.
+    # `dbopen` creates new client storage connection and wraps it with DB.
     def dbopen(self):
         try:
             zstor = self._new_storage_client()
@@ -255,7 +256,7 @@ class RaceTests(object):
     def _check_race_load_vs_external_invalidate(self, spec):
         assert IModelSpec.providedBy(spec)
 
-        # init initializes the database according to the spec.
+        # `init` initializes the database according to the spec.
         def init():
             db = self.dbopen()
             _state_init(db, spec)
@@ -270,7 +271,7 @@ class RaceTests(object):
         # nwork=4.
         nwork = 8
 
-        # T is a worker that accesses database in a loop and verifies
+        # `T` is a worker that accesses database in a loop and verifies
         # spec invariant.
         #
         # Access to half of the objects is organized to always trigger loading
@@ -365,7 +366,7 @@ class RaceTests(object):
     def _check_race_external_invalidate_vs_disconnect(self, spec):
         assert IModelSpec.providedBy(spec)
 
-        # init initializes the database according to the spec.
+        # `init` initializes the database according to the spec.
         def init():
             db = self.dbopen()
             _state_init(db, spec)
@@ -373,7 +374,7 @@ class RaceTests(object):
 
         nwork = 8*8   # nwork^2 from _check_race_load_vs_external_invalidate
 
-        # T is similar to the T from _check_race_load_vs_external_invalidate
+        # `T` is similar to the T from _check_race_load_vs_external_invalidate
         # but reconnects to the database often.
         failed = threading.Event()
         failure = [None] * nwork  # [tx] is failure from T(tx)
@@ -451,7 +452,7 @@ class RaceTests(object):
             self.fail('\n\n'.join([_ for _ in failure if _]))
 
 
-# _state_init initializes the database according to the spec.
+# `_state_init` initializes the database according to the spec.
 def _state_init(db, spec):
     transaction.begin()
     zconn = db.open()
@@ -462,8 +463,8 @@ def _state_init(db, spec):
     zconn.close()
 
 
-# _state_invalidate_half1 invalidatates first 50% of database objects, so that
-# the next time they are accessed, they are reloaded from the storage.
+# `_state_invalidate_half1` invalidatates first 50% of database objects, so
+# that the next time they are accessed, they are reloaded from the storage.
 def _state_invalidate_half1(root):
     keys = list(sorted(root.keys()))
     for k in keys[:len(keys)//2]:
@@ -471,8 +472,8 @@ def _state_invalidate_half1(root):
         obj._p_invalidate()
 
 
-# _state_details returns text details about ZODB objects directly referenced by
-# root.
+# `_state_details` returns text details about ZODB objects directly referenced
+# by root.
 def _state_details(root):  # -> txt
     # serial for all objects
     keys = list(sorted(root.keys()))

--- a/src/ZODB/tests/util.py
+++ b/src/ZODB/tests/util.py
@@ -113,6 +113,23 @@ class TestCase(unittest.TestCase):
 
     tearDown = tearDown
 
+    # propagate .level from tested method to TestCase so that e.g. @long_test
+    # works
+    @property
+    def level(self):
+        f = getattr(self, self._testMethodName)
+        return getattr(f, 'level', 1)
+
+
+def long_test(f):
+    """
+    long_test decorates f to be marked as long-running test.
+
+    Use `zope-testrunner --at-level=1` to run tests without the long-ones.
+    """
+    f.level = 2
+    return f
+
 
 def pack(db):
     db.pack(time.time()+1)

--- a/src/ZODB/utils.py
+++ b/src/ZODB/utils.py
@@ -403,3 +403,13 @@ def load_current(storage, oid, version=''):
         raise ZODB.POSException.POSKeyError(oid)
     assert r[2] is None
     return r[:2]
+
+
+def at2before(at):  # -> before
+    """at2before converts `at` TID to corresponding `before`."""
+    return p64(u64(at) + 1)
+
+
+def before2at(before):  # -> at
+    """before2at converts `before` TID to corresponding `at`."""
+    return p64(u64(before) - 1)

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
 setenv =
     ZOPE_INTERFACE_STRICT_IRO=1
 commands =
-    zope-testrunner --test-path=src {posargs:-vc}
+    zope-testrunner --test-path=src --all {posargs:-vc}
 extras =
     test
 


### PR DESCRIPTION
Add test for Bug2 described in https://github.com/zopefoundation/ZEO/issues/209 + modernize race testing infrastructure. We add this test here, so that it can be run automatically for all storages - e.g. both ZEO and NEO.

ZEO currently can corrupt data if client disconnects simultaneously to another client performing `tpc_finish`. It fails e.g. as follows:

```console
(z-dev) kirr@deca:~/src/wendelin/z/ZEO5$ ZEO_MTACCEPTOR=1 zope-testrunner -fvvvx --test-path=src -t check_race_external_invalidate_vs_disconnect
/home/kirr/src/wendelin/venv/z-dev/bin/zope-testrunner traceio=True
/home/kirr/src/wendelin/z/ZEO5/src/ZEO/StorageServer.py:51: DeprecationWarning: The mtacceptor module is deprecated and will be removed in ZEO version 6.
  'in ZEO version 6.', DeprecationWarning)
Running tests at level 1
Running .BlobAdaptedFileStorageTests tests:
  Set up .BlobAdaptedFileStorageTests in 0.000 seconds.
  Running:
 check_race_external_invalidate_vs_disconnect (ZEO.tests.testZEO.BlobAdaptedFileStorageTests) (1.889 s)

Failure in test check_race_external_invalidate_vs_disconnect (ZEO.tests.testZEO.BlobAdaptedFileStorageTests)
Traceback (most recent call last):
  File "/usr/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/home/kirr/src/wendelin/z/ZODB/src/ZODB/tests/racetest.py", line 357, in check_race_external_invalidate_vs_disconnect
    T2ObjectsInc2Phase())
  File "/home/kirr/src/wendelin/z/ZODB/src/ZODB/tests/util.py", line 400, in _
    return f(*argv, **kw)
  File "/home/kirr/src/wendelin/z/ZODB/src/ZODB/tests/racetest.py", line 446, in _check_race_xxx_vs_external_disconnect
    self.fail('\n\n'.join([_ for _ in failure if _]))
  File "/usr/lib/python2.7/unittest/case.py", line 410, in fail
    raise self.failureException(msg)
AssertionError: T15: obj1 (6) - obj2(4) != phase (1)
obj1._p_serial: 0x03ea4cc505486777  obj2._p_serial: 0x03ea4cc503413799  phase._p_serial: 0x03ea4cc505486777
zconn_at: 0x03ea4cc505486777  # approximated as max(serials)
zstor.loadBefore(obj1, @zconn.at)       ->  serial: 0x03ea4cc505486777  next_serial: None
zstor.loadBefore(obj2, @zconn.at)       ->  serial: 0x03ea4cc504a74099  next_serial: None
zstor.loadBefore(phase, @zconn.at)      ->  serial: 0x03ea4cc505486777  next_serial: None
zstor._cache.clear()
zstor.loadBefore(obj1, @zconn.at)       ->  serial: 0x03ea4cc505486777  next_serial: None
zstor.loadBefore(obj2, @zconn.at)       ->  serial: 0x03ea4cc504a74099  next_serial: 0x03ea4cc506104155
zstor.loadBefore(phase, @zconn.at)      ->  serial: 0x03ea4cc505486777  next_serial: 0x03ea4cc506104155

T51: obj1 (6) - obj2(4) != phase (1)
obj1._p_serial: 0x03ea4cc505486777  obj2._p_serial: 0x03ea4cc503413799  phase._p_serial: 0x03ea4cc505486777
zconn_at: 0x03ea4cc505486777  # approximated as max(serials)
zstor.loadBefore(obj1, @zconn.at)       ->  serial: 0x03ea4cc505486777  next_serial: None
zstor.loadBefore(obj2, @zconn.at)       ->  serial: 0x03ea4cc503413799  next_serial: None
zstor.loadBefore(phase, @zconn.at)      ->  serial: 0x03ea4cc505486777  next_serial: None
zstor._cache.clear()
zstor.loadBefore(obj1, @zconn.at)       ->  serial: 0x03ea4cc505486777  next_serial: None
zstor.loadBefore(obj2, @zconn.at)       ->  serial: 0x03ea4cc504a74099  next_serial: None
zstor.loadBefore(phase, @zconn.at)      ->  serial: 0x03ea4cc505486777  next_serial: None
```

Please see individual patches for details.