### PR TITLE
tox: `zope-testrunner --all`  ->  `zope.testrunner -a 1000`

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -15,7 +15,7 @@ with-sphinx-doctests = false
 [tox]
 use-flake8 = true
 testenv-commands = [
-    "zope-testrunner --test-path=src --all {posargs:-vc}",
+    "zope-testrunner --test-path=src -a 1000 {posargs:-vc}",
     ]
 testenv-setenv = [
     "ZOPE_INTERFACE_STRICT_IRO=1",

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
 setenv =
     ZOPE_INTERFACE_STRICT_IRO=1
 commands =
-    zope-testrunner --test-path=src --all {posargs:-vc}
+    zope-testrunner --test-path=src -a 1000 {posargs:-vc}
 extras =
     test
 


### PR DESCRIPTION
Because `--all` takes precedence over any followup `-a X` on command
line in e.g. `tox -- -a 1`. See

    https://github.com/zopefoundation/ZEO/commit/06f8e1461c05

and

    https://github.com/zopefoundation/ZEO/pull/210#pullrequestreview-1094352596

for details.