### PR TITLE
Fix `racetest` problems

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 5.8.1 (unreleased)
 ==================
 
+- Fix ``racetest`` problems.
+  For details see `#376 <https://github.com/zopefoundation/ZODB/pull/376>`_.
+
 
 5.8.0 (2022-11-09)
 ==================

--- a/src/ZODB/scripts/zodbload.py
+++ b/src/ZODB/scripts/zodbload.py
@@ -227,7 +227,7 @@ def VmSize():
     except:  # noqa: E722 do not use bare 'except'
         return 0
     else:
-        l_ = list(filter(lambda l: l[:7] == 'VmSize:', lines))
+        l_ = list(filter(lambda l: l[:7] == 'VmSize:', lines))  # noqa: E741
         if l_:
             l_ = l_[0][7:].strip().split()[0]
             return int(l_)

--- a/src/ZODB/tests/racetest.py
+++ b/src/ZODB/tests/racetest.py
@@ -536,4 +536,3 @@ class Daemon(threading.Thread):
         super(Daemon, self).join(*args, **kw)
         if self.is_alive():
             raise AssertionError("Thread %s did not stop" % self.name)
-

--- a/src/ZODB/tests/racetest.py
+++ b/src/ZODB/tests/racetest.py
@@ -529,8 +529,8 @@ def _state_details(root):  # -> txt
 class Daemon(threading.Thread):
     """auxiliary class to create daemon threads and fail if not stopped."""
     def __init__(self, **kw):
-        kw["daemon"] = True
         super(Daemon, self).__init__(**kw)
+        self.daemon = True
 
     def join(self, *args, **kw):
         super(Daemon, self).join(*args, **kw)

--- a/src/ZODB/tests/racetest.py
+++ b/src/ZODB/tests/racetest.py
@@ -214,9 +214,9 @@ class RaceTests(object):
         init()
 
         N = 500
-        tverify = threading.Thread(
+        tverify = Daemon(
             name='Tverify', target=xrun, args=(verify, N))
-        tmodify = threading.Thread(
+        tmodify = Daemon(
             name='Tmodify', target=xrun, args=(modify, N))
         tverify.start()
         tmodify.start()
@@ -340,7 +340,7 @@ class RaceTests(object):
         N = 100
         tg = []
         for x in range(nwork):
-            t = threading.Thread(name='T%d' % x, target=T, args=(x, N))
+            t = Daemon(name='T%d' % x, target=T, args=(x, N))
             t.start()
             tg.append(t)
 
@@ -446,7 +446,7 @@ class RaceTests(object):
         N = 100 // (2*4)  # N reduced to save time
         tg = []
         for x in range(nwork):
-            t = threading.Thread(name='T%d' % x, target=T, args=(x, N))
+            t = Daemon(name='T%d' % x, target=T, args=(x, N))
             t.start()
             tg.append(t)
 
@@ -524,3 +524,16 @@ def _state_details(root):  # -> txt
             txt += load(k)
 
     return txt
+
+
+class Daemon(threading.Thread):
+    """auxiliary class to create daemon threads and fail if not stopped."""
+    def __init__(self, **kw):
+        kw["daemon"] = True
+        super(Daemon, self).__init__(**kw)
+
+    def join(self, *args, **kw):
+        super(Daemon, self).join(*args, **kw)
+        if self.is_alive():
+            raise AssertionError("Thread %s did not stop" % self.name)
+


### PR DESCRIPTION
This PR fixes problems with the `racetest`s observed during work on "https://github.com/zopefoundation/ZEO/pull/225".

It uses daemon (rather than normal) threads to avoid deadlock on shutdown when one of the test threads has not finished. It treats the failure for a test thread to finish as a test failure.