### PR TITLE
`racetest` improvement

### DIFF
--- a/src/ZODB/tests/racetest.py
+++ b/src/ZODB/tests/racetest.py
@@ -465,9 +465,9 @@ class RaceTests(object):
             try:
                 t.join(1)
             except AssertionError:
+                failed.set()
                 failed_to_finish.append(t.name)
         if failed_to_finish:
-            failed.set()
             failure.append("threads did not finish: %s" % failed_to_finish)
 
         if failed.is_set():


### PR DESCRIPTION
This PR tries to facilitate the failure analysis for `check_race_external_invalidate_vs_disconnect`.

"https://github.com/zopefoundation/ZEO/pull/228" suffers occasionally from a failure of the test above. Unfortunately, the failure output is extremely difficult to analyze:
* exception and traceback lines from concurrent threads are mixed; it is almost impossible to reconstruct the exception/traceback information belonging to an individual thread
* if a thread fails to stop, information about potential other problems is lost

The PR protects the output of exception/traceback information from the concurrent threads with a lock and thereby prevents that the corresponding lines are mixed: exception output from one thread remains contiguous.
The PR also checks explicitly that the test finishes within the expected time. If this fails, a speaking failure is generated. Formerly, a too slow execution was recognized by one of the threads not stopping.
Finally, all threads are given a chance to stop gracefully in case of a problem -- formlerly the first thread which did not stop within the expected time cause the test to be terminated; the resulting server shutdown cause a huge amount of irrelevant `ClientDisconnected` exceptions.
