### PR TITLE
fix(repozo) `--with-verify` argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@
 - Fix ``racetest`` problems.
   For details see `#376 <https://github.com/zopefoundation/ZODB/pull/376>`_.
 
+- Fix ``--with-verify`` argument in script repozo ``--recover``.
+  For details see `#381 <https://github.com/zopefoundation/ZODB/pull/381>`_.
+
 
 5.8.0 (2022-11-09)
 ==================

--- a/src/ZODB/scripts/repozo.py
+++ b/src/ZODB/scripts/repozo.py
@@ -74,7 +74,7 @@ Options for -R/--recover:
         automatically.
 
     -w
-    --with-verification
+    --with-verify
         Verify on the fly the backup files on recovering. This option runs
         the same checks as when repozo is run in -V/--verify mode, and
         allows to verify and recover a backup in one single step. If a sanity
@@ -179,7 +179,7 @@ def parseargs(argv):
                                     'kill-old-on-full',
                                     'date=',
                                     'output=',
-                                    'with-verification',
+                                    'with-verify',
                                     ])
     except getopt.error as msg:
         usage(1, msg)


### PR DESCRIPTION
The argument `--with-verification` for `--recover` does not work.

"verify" is used 39 times in the script, and "verification" is used only 2 times.
I think the two occurrences of `--with-verification` should be `--with-verify`. 
The script then works and the doc is correct.