### PR TITLE
Remove potentially-buggy positive_id

### DIFF
--- a/src/ZODB/Connection.py
+++ b/src/ZODB/Connection.py
@@ -53,7 +53,6 @@ from ZODB.serialize import ObjectReader
 from ZODB.serialize import ObjectWriter
 from ZODB.utils import oid_repr
 from ZODB.utils import p64
-from ZODB.utils import positive_id
 from ZODB.utils import u64
 from ZODB.utils import z64
 
@@ -946,15 +945,6 @@ class Connection(ExportImport, object):
             c._storage = c._normal_storage = None
             c._cache = PickleCache(self, 0, 0)
             c.close(False)
-
-    ##########################################################################
-    # Python protocol
-
-    def __repr__(self):
-        return '<Connection at %08x>' % (positive_id(self),)
-
-    # Python protocol
-    ##########################################################################
 
     ##########################################################################
     # DEPRECATION candidates

--- a/src/ZODB/utils.py
+++ b/src/ZODB/utils.py
@@ -41,7 +41,6 @@ __all__ = ['z64',
            'oid_repr',
            'serial_repr',
            'tid_repr',
-           'positive_id',
            'readable_tid_repr',
            'get_pickle_metadata',
            'locked',
@@ -182,28 +181,6 @@ def readable_tid_repr(tid):
     result = tid_repr(tid)
     if isinstance(tid, bytes) and len(tid) == 8:
         result = "%s %s" % (result, TimeStamp(tid))
-    return result
-
-# Addresses can "look negative" on some boxes, some of the time.  If you
-# feed a "negative address" to an %x format, Python 2.3 displays it as
-# unsigned, but produces a FutureWarning, because Python 2.4 will display
-# it as signed.  So when you want to prodce an address, use positive_id() to
-# obtain it.
-# _ADDRESS_MASK is 2**(number_of_bits_in_a_native_pointer).  Adding this to
-# a negative address gives a positive int with the same hex representation as
-# the significant bits in the original.
-
-
-_ADDRESS_MASK = 256 ** struct.calcsize('P')
-
-
-def positive_id(obj):
-    """Return id(obj) as a non-negative integer."""
-
-    result = id(obj)
-    if result < 0:
-        result += _ADDRESS_MASK
-        assert result > 0
     return result
 
 # Given a ZODB pickle, return pair of strings (module_name, class_name).


### PR DESCRIPTION
positive_id was added in 2004 in f7b96aea (ZODB.utils grows a new function positive_id(), which returns the id() of an object as a non-negative integer ...) to workaround change in behaviour Python2.3 -> 2.4 for `'%x' % <negative-number>`. And nowdays `positive_id` is used only in one place in Connection.__repr__ to mimic approximately what Python already gives for a default __repr__ out of the box.

On https://github.com/zopefoundation/ZODB/actions/runs/5067242751/jobs/9098062772 we recently hit

    ZODB.POSException.InvalidObjectReference: <unprintable InvalidObjectReference object>

for the following code:

    if self._jar.get_connection(database_name) is not obj._p_jar:
        raise InvalidObjectReference(
            "Attempt to store a reference to an object from "
            "a separate connection to the same database or "
            "multidatabase", self._jar, obj,
        )

( https://github.com/zopefoundation/ZODB/blob/5.8.0-24-g8a7e3162d/src/ZODB/serialize.py#L366-L371 )

for which the "unprintable ..." part is produced by `Lib/traceback.py` who tries to do `str(ex)` and returns `unprintable ...` if that str failed:

https://github.com/python/cpython/blob/v3.8.16-18-g9f89c471fb1/Lib/traceback.py#L153-L157

Since one of the reasons for that failure might have been a bit non-trivial code and assert in positive_id, let's remove it and rely on builtin python behaviour for Connection repr.

repr for Connection:

before this patch:

    <Connection at 0x7fef09989d10>

after this patch:

    <ZODB.Connection.Connection object at 0x7fef09989d10>