### PR TITLE
Update blob.py

### DIFF
--- a/src/ZODB/blob.py
+++ b/src/ZODB/blob.py
@@ -946,7 +946,7 @@ if sys.platform == 'win32':
 else:
     remove_committed = os.remove
     remove_committed_dir = shutil.rmtree
-    
+
     try:
         link_or_copy = os.link
     except AttributeError:  # pragma: no cover


### PR DESCRIPTION
This fix works for any installation of ZODB on unspecified platforms like Android.  It is proposed for the termux version of ZODB. 

While a pip install zodb within the termux distro for Android completes without incident, it fails to run since any attempts to import ZODB within termux's python fails.  This is because their python's os.link has been disabled for some cross platform reason related to Windows.

The only ZODB library code which uses os.link is in ZODB.blob.py where it is selected as the value for the link_or_copy name on Posix systems.  On Windows systems, it is mapped to shutil.copy.  

This pull request extends the mapping of link_or_copy to shutil.copy for Android, not by attempting to identify the platform as Android, but by attempting a try:except snippet.

Closes #257.