### PR TITLE
fix sorting dict items

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
 
 - Drop support for Python 2.7, 3.5, 3.6.
 
+- Fix sorting of dict items in script space (py3 not OK with py2 syntax)
+
 
 5.8.1 (2023-07-18)
 ==================

--- a/src/ZODB/scripts/space.py
+++ b/src/ZODB/scripts/space.py
@@ -8,6 +8,8 @@ The current implementation only supports FileStorage.
 Current limitations / simplifications: Ignores revisions and versions.
 """
 
+from operator import itemgetter
+
 from ZODB.FileStorage import FileStorage
 from ZODB.utils import U64
 from ZODB.utils import get_pickle_metadata
@@ -32,9 +34,7 @@ def run(path, v=0):
         totals[key] = bytes, count
         if v:
             print("%8s %5d %s" % (U64(oid), len(data), key))
-    L = totals.items()
-    L.sort(key=lambda x: x[1])
-    L.reverse()
+    L = sorted(totals.items(), key=itemgetter(1), reverse=True)
     print("Totals per object class:")
     for key, (bytes, count) in L:
         print("%8d %8d %s" % (count, bytes, key))


### PR DESCRIPTION
`dict_items` instance does not have a `sort` method