### PR TITLE
repozo: exit with non-zero code in case of verification failure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
 
 - Fix sorting issue in ``scripts/space.py``.
 
+- Fix exit code of ``repozo`` script in case of verification error.
+  For details see `#396 <https://github.com/zopefoundation/ZODB/pull/396>`_.
 
 5.8.1 (2023-07-18)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@
 - Fix exit code of ``repozo`` script in case of verification error.
   For details see `#396 <https://github.com/zopefoundation/ZODB/pull/396>`_.
 
+
 5.8.1 (2023-07-18)
 ==================
 

--- a/src/ZODB/scripts/repozo.py
+++ b/src/ZODB/scripts/repozo.py
@@ -780,15 +780,16 @@ def do_verify(options):
                         filename, options.quick)
                     when_uncompressed = ''
             except OSError:
-                error("%s is missing", filename)
-                continue
+                raise VerificationFail("%s is missing" % filename)
             if size != expected_size:
-                error("%s is %d bytes%s, should be %d bytes", filename,
-                      size, when_uncompressed, expected_size)
+                raise VerificationFail(
+                    "%s is %d bytes%s, should be %d bytes" % (
+                        filename, size, when_uncompressed, expected_size))
             elif not options.quick:
                 if actual_sum != sum:
-                    error("%s has checksum %s%s instead of %s", filename,
-                          actual_sum, when_uncompressed, sum)
+                    raise VerificationFail(
+                        "%s has checksum %s%s instead of %s" % (
+                            filename, actual_sum, when_uncompressed, sum))
 
 
 def get_checksum_and_size_of_gzipped_file(filename, quick):


### PR DESCRIPTION
When verification failed, repozo prints a message on standard error, but the program always exits with a return code indicating a success. In case of error it's more natural to exit with an error return code.