### PR TITLE
Fix behavior of ``FileStorage.restore`` when provided wrong ``prev_txn``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@
 
 - Fix sorting issue in ``scripts/space.py``.
 
+- Fix behavior of ``FileStorage.restore`` when provided wrong ``prev_txn``.
+  For details see `#397 <https://github.com/zopefoundation/ZODB/pull/397>`_.
+
 
 5.8.1 (2023-07-18)
 ==================

--- a/src/ZODB/FileStorage/FileStorage.py
+++ b/src/ZODB/FileStorage/FileStorage.py
@@ -1048,6 +1048,8 @@ class FileStorage(
             tid = decodebytes(transaction_id + b'\n')
             assert len(tid) == 8
             tpos = self._txn_find(tid, 1)
+            if not tpos:
+                raise UndoError("Invalid transaction id")
             tindex = self._txn_undo_write(tpos)
             self._tindex.update(tindex)
             return self._tid, tindex.keys()
@@ -1066,7 +1068,7 @@ class FileStorage(
                 # check the status field of the transaction header
                 if h[16] == b'p':
                     break
-        raise UndoError("Invalid transaction id")
+        return None
 
     def _txn_undo_write(self, tpos):
         # a helper function to write the data records for transactional undo

--- a/src/ZODB/FileStorage/FileStorage.py
+++ b/src/ZODB/FileStorage/FileStorage.py
@@ -672,7 +672,7 @@ class FileStorage(
         tid, tl, status, ul, dl, el = unpack(TRANS_HDR, h)
         status = as_text(status)
         self._file.read(ul + dl + el)
-        tend = tpos + tl + 8
+        tend = tpos + tl
         pos = self._file.tell()
         while pos < tend:
             h = self._read_data_header(pos)

--- a/src/ZODB/tests/testFileStorage.py
+++ b/src/ZODB/tests/testFileStorage.py
@@ -259,6 +259,30 @@ class FileStorageTests(
         self._storage.tpc_finish(t)
         self.assertEqual(self._storage.load(oid)[0], b'data1b')
 
+    def testRestorePrevTxnWithoutOid(self):
+        t = TransactionMetaData()
+        self._storage.tpc_begin(t)
+        self._storage.store(b'\1' * 8, b'\0' * 8, b'data1', b'', t)
+        self._storage.tpc_vote(t)
+        tid1 = self._storage.tpc_finish(t)
+
+        # this transaction is also here to detect problems if restore reads
+        # below the end of tid1
+        t = TransactionMetaData()
+        self._storage.tpc_begin(t)
+        self._storage.store(b'\2' * 8, b'\0' * 8, b'data2a', b'', t)
+        self._storage.tpc_vote(t)
+        self._storage.tpc_finish(t)
+
+        # restore with a transaction not containing the oid
+        t = TransactionMetaData()
+        self._storage.tpc_begin(t)
+        self._storage.restore(b'\2' * 8, b'\0' * 8, b'data2b', b'', tid1, t)
+        self._storage.tpc_vote(t)
+        self._storage.tpc_finish(t)
+        self.assertEqual(self._storage.load(b'\1' * 8)[0], b'data1')
+        self.assertEqual(self._storage.load(b'\2' * 8)[0], b'data2b')
+
     def testCorruptionInPack(self):
         # This sets up a corrupt .fs file, with a redundant transaction
         # length mismatch.  The implementation of pack in many releases of

--- a/src/ZODB/tests/testFileStorage.py
+++ b/src/ZODB/tests/testFileStorage.py
@@ -242,6 +242,23 @@ class FileStorageTests(
         # Before ZODB 3.2.6, this failed, with ._oid == z64.
         self.assertEqual(self._storage._oid, giant_oid)
 
+    def testRestorePrevTxnNotExists(self):
+        t = TransactionMetaData()
+        oid = b'\1' * 8
+        self._storage.tpc_begin(t)
+        self._storage.store(oid, b'\0' * 8, b'data1a', b'', t)
+        self._storage.tpc_vote(t)
+        self._storage.tpc_finish(t)
+
+        # restore with a transaction not existing in the storage
+        tid_not_exist = b'\0\0\0\0\0\1\2\3'
+        t = TransactionMetaData()
+        self._storage.tpc_begin(t)
+        self._storage.restore(oid, b'\0' * 8, b'data1b', b'', tid_not_exist, t)
+        self._storage.tpc_vote(t)
+        self._storage.tpc_finish(t)
+        self.assertEqual(self._storage.load(oid)[0], b'data1b')
+
     def testCorruptionInPack(self):
         # This sets up a corrupt .fs file, with a redundant transaction
         # length mismatch.  The implementation of pack in many releases of


### PR DESCRIPTION
See discussions from https://github.com/zopefoundation/ZODB/pull/395#discussion_r1474127300 about removing ` + 8 ` from `tend`