### PR TITLE
repozo: prevent an incorrect "option ignored" warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 6.0.1 (unreleased)
 ==================
 
+ - repozo: prevent an incorrect "option ignored" warning when running backup or verify.
+
 
 6.0 (2024-03-20)
 ================

--- a/src/ZODB/scripts/repozo.py
+++ b/src/ZODB/scripts/repozo.py
@@ -249,9 +249,9 @@ def parseargs(argv):
         if options.output is not None:
             log('--output option is ignored in backup mode')
             options.output = None
-        if options.withverify is not None:
+        if options.withverify:
             log('--with-verify option is ignored in backup mode')
-            options.withverify = None
+            options.withverify = False
         if not options.file:
             usage(1, '--file is required in backup mode')
     elif options.mode == RECOVER:
@@ -281,9 +281,9 @@ def parseargs(argv):
         if options.killold:
             log('--kill-old-on-full option is ignored in verify mode')
             options.killold = False
-        if options.withverify is not None:
+        if options.withverify:
             log('--with-verify option is ignored in verify mode')
-            options.withverify = None
+            options.withverify = False
     return options
 
 

--- a/src/ZODB/scripts/tests/test_repozo.py
+++ b/src/ZODB/scripts/tests/test_repozo.py
@@ -189,6 +189,7 @@ class Test_parseargs(unittest.TestCase):
     def test_backup_ignored_args(self):
         from ZODB.scripts import repozo
         options = repozo.parseargs(['-B', '-r', '/tmp/nosuchdir', '-v',
+                                    '--with-verify',
                                     '-f', '/tmp/Data.fs',
                                     '-o', '/tmp/ignored.fs',
                                     '-D', '2011-12-13'])
@@ -198,12 +199,22 @@ class Test_parseargs(unittest.TestCase):
         self.assertEqual(options.output, None)
         self.assertIn('--output option is ignored in backup mode',
                       sys.stderr.getvalue())
+        self.assertEqual(options.withverify, False)
+        self.assertIn(
+            '--with-verify option is ignored in backup mode',
+            sys.stderr.getvalue())
 
     def test_backup_required_args(self):
         from ZODB.scripts import repozo
         self.assertRaises(SystemExit, repozo.parseargs,
                           ['-B', '-r', '/tmp/nosuchdir'])
         self.assertIn('--file is required', sys.stderr.getvalue())
+
+    def test_backup_no_ignored_args_warning(self):
+        from ZODB.scripts import repozo
+        repozo.parseargs(['-B', '-r', '/tmp/nosuchdir', '-v',
+                          '-f', '/tmp/Data.fs',])
+        self.assertNotIn('option is ignored', sys.stderr.getvalue())
 
     def test_recover_ignored_args(self):
         from ZODB.scripts import repozo
@@ -220,6 +231,7 @@ class Test_parseargs(unittest.TestCase):
     def test_verify_ignored_args(self):
         from ZODB.scripts import repozo
         options = repozo.parseargs(['-V', '-r', '/tmp/nosuchdir', '-v',
+                                    '--with-verify',
                                     '-o', '/tmp/ignored.fs',
                                     '-D', '2011-12-13',
                                     '-f', '/tmp/ignored.fs',
@@ -241,6 +253,9 @@ class Test_parseargs(unittest.TestCase):
                       sys.stderr.getvalue())
         self.assertEqual(options.killold, False)
         self.assertIn('--kill-old-on-full option is ignored in verify mode',
+                      sys.stderr.getvalue())
+        self.assertEqual(options.withverify, False)
+        self.assertIn('--with-verify option is ignored in verify mode',
                       sys.stderr.getvalue())
 
 


### PR DESCRIPTION
When running backup or verify, "--with-verify option is ignored" warning was issued even when this option was not passed