### PR TITLE
repozo: fix recover on stdout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 6.0.1 (unreleased)
 ==================
 
+- repozo: fix restoring on stdout.
+
 
 6.0 (2024-03-20)
 ================

--- a/src/ZODB/scripts/repozo.py
+++ b/src/ZODB/scripts/repozo.py
@@ -685,7 +685,7 @@ def do_recover(options):
     files_to_close = ()
     if options.output is None:
         log('Recovering file to stdout')
-        outfp = sys.stdout
+        outfp = sys.stdout.buffer
     else:
         # Delete old ZODB before recovering backup as size of
         # old ZODB + full partial file may be superior to free disk space


### PR DESCRIPTION
This was working on python2, but on python3,

```
  repozo -v --recover --repository backups/ > restored.fs
```

failed with

```  
  TypeError: write() argument must be str, not bytes
```