### PR TITLE
*: Fix flake8 errors

### DIFF
--- a/src/ZODB/scripts/checkbtrees.py
+++ b/src/ZODB/scripts/checkbtrees.py
@@ -24,8 +24,6 @@ oids_seen = {}
 
 
 def add_if_new_persistent(L, obj, path):
-    global oids_seen
-
     getattr(obj, '_', None)  # unghostify
     if hasattr(obj, '_p_oid'):
         oid = obj._p_oid

--- a/src/ZODB/tests/speed.py
+++ b/src/ZODB/tests/speed.py
@@ -79,7 +79,6 @@ def main(args):
         elif o == '-M':
             detailed = 0
         elif o == '-D':
-            global debug
             os.environ['STUPID_LOG_FILE'] = ''
             os.environ['STUPID_LOG_SEVERITY'] = '-999'
 


### PR DESCRIPTION
    ZODB$ python3 -m flake8 src setup.py
    src/ZODB/scripts/checkbtrees.py:27:5: F824 `global oids_seen` is unused: name is never assigned in scope
    src/ZODB/tests/speed.py:82:13: F824 `global debug` is unused: name is never assigned in scope

This are causing CI failure, e.g. https://github.com/zopefoundation/ZODB/actions/runs/14292354109/job/40055215015