### PR TITLE
Updating ubuntu from 20.04 to 24.04, which removes py37, but fixing ci as ubuntu 20.04 is retired.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ["ubuntu", "ubuntu-20.04"]
+        - ["ubuntu", "ubuntu-24.04"]
         - ["windows", "windows-latest"]
         config:
         # [Python version, tox env]
@@ -38,6 +38,8 @@ jobs:
           - { os: ["windows", "windows-latest"], config: ["3.9",   "lint"] }
           - { os: ["windows", "windows-latest"], config: ["3.9",   "docs"] }
           - { os: ["windows", "windows-latest"], config: ["3.9",   "coverage"] }
+          - { os: ["ubuntu", "ubuntu-24.04"], config: ["3.7",   "py37"] }
+
 
     runs-on: ${{ matrix.os[1] }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name


### PR DESCRIPTION
Ubuntu 20.04 was retired in April and the ci has been timing out ever since and is labelled has failing on the page.

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

We might want to drop support for python 3.7 as it isn't in 24.04.

I've added excludes so 3.7 for ubuntu but left it for windows as it still ruuns there. I can update readme and remove 3.7 everywhere if wanted.

ci now green.


- [ ] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added documentation for my changes.
- [ ] I included a change log entry in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #
